### PR TITLE
Bump release to 1.1.1

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -88,6 +88,8 @@ program
 .option('--scan-interval <ms>', 'If `--mode scan`, the interval between scans. Ignored if `--mode events`.', parseIntegerArg,  parseIntegerEnv(pe.WATCHER_SCAN_INTERVAL) ?? 300000)
 .option('--ignore-dot', 'Ignore dotfiles in the path (`WATCHER_IGNORE_DOT=1`). Negate with `--no-ignore-dot`.', getBoolean('WATCHER_IGNORE_DOT', true))
 .option('--no-ignore-dot', 'Do not ignore dotfiles in the path (`WATCHER_IGNORE_DOT=0`).')
+.option('--strict-revision-check', 'For CKL, ignore checklist of uninstalled STIG revision (`WATCHER_STRICT_REVISION_CHECK=1`). Negate with `--no-strict-revision-check`.', getBoolean('WATCHER_STRICT_REVISION_CHECK', false))
+.option('--no-strict-revision-check', 'For CKL, allow checklist of uninstalled STIG revision (`WATCHER_STRICT_REVISION_CHECK=0`). This is the default behavior.')
 
 // Parse ARGV and get the parsed options object
 program.parse(process.argv)

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -136,7 +136,7 @@ class TaskObject {
       const stigIsInstalled = ( { benchmarkId, revisionStr } ) => {
         const revisionStrs = this.mappedStigs.get( benchmarkId )
         if ( revisionStrs ) {
-          return revisionStrs.includes( revisionStr )
+          return revisionStr && config.strictRevisionCheck ? revisionStrs.includes( revisionStr ) : true
         }
         else {
           return false

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,10 +1,9 @@
 const parser = require('fast-xml-parser')
 const Queue = require('better-queue')
-const he = require('he')
 const { logger } = require('./logger')
 const cargo = require('./cargo')
 const fs = require('fs').promises
-const { resolve } = require('path')
+const tagValueProcessor = require('he').decode
 
 // const parseResult = {
 //   type: 'CKL' || 'XCCDF',
@@ -33,10 +32,15 @@ const { resolve } = require('path')
 //         }
 //       ],
 //       stats: {
-//         pass: 0,
-//         fail: 0,
-//         notapplicable: 0,
-//         notchecked: 0
+//          pass: 0,
+//          fail: 0,
+//          notapplicable: 0,
+//          notchecked: 0,
+//          notselected: 0,
+//          informational: 0,
+//          error: 0,
+//          fixed: 0,
+//          unknown: 0
 //       }
 //     }
 //   ]
@@ -58,7 +62,7 @@ const reviewsFromCkl = function reviewsFromCkl (cklData, options = {}) {
       localeRange: "", //To support non english character in tag/attribute values.
       parseTrueNumberOnly: false,
       arrayMode: true, //"strict"
-      tagValueProcessor: val => he.decode(val)
+      tagValueProcessor: val => tagValueProcessor(val)
     }
     let parsed = parser.parse(cklData, fastparseOptions)
 
@@ -90,7 +94,9 @@ const reviewsFromCkl = function reviewsFromCkl (cklData, options = {}) {
       if (assetElement.ROLE) {
         metadata.cklRole = assetElement.ROLE
       }
-
+      if (assetElement.TECH_AREA) {
+        metadata.cklTechArea = assetElement.TECH_AREA
+      }
       if (assetElement.WEB_OR_DATABASE) {
         metadata.cklWebOrDatabase = 'true'
         metadata.cklHostName = assetElement.HOST_NAME
@@ -140,32 +146,29 @@ const reviewsFromCkl = function reviewsFromCkl (cklData, options = {}) {
       //     STIG_DATA [26]
       // }
   
-      const results = {
+      const resultMap = {
         NotAFinding: 'pass',
         Open: 'fail',
         Not_Applicable: 'notapplicable',
         Not_Reviewed: 'notchecked'
       }
+      const resultStats = {
+        pass: 0,
+        fail: 0,
+        notapplicable: 0,
+        notchecked: 0,
+        notselected: 0,
+        informational: 0,
+        error: 0,
+        fixed: 0,
+        unknown: 0
+      }  
       let vulnArray = []
-      let nf = na = nr = o = 0
       vulnElements?.forEach(vuln => {
-        const result = results[vuln.STATUS]
+        let result = resultMap[vuln.STATUS]
         if (result) {
-          switch (result) {
-            case 'pass':
-                nf++
-                break
-            case 'fail':
-                o++
-                break
-            case 'notapplicable':
-                na++
-                break
-            case 'notchecked':
-                nr++
-                break
-          }
-
+          if (result === 'notchecked' && vuln.FINDING_DETAILS) result = 'informational'
+          resultStats[result]++
           let ruleId
           vuln.STIG_DATA.some(stigDatum => {
             if (stigDatum.VULN_ATTRIBUTE == "Rule_ID") {
@@ -198,7 +201,6 @@ const reviewsFromCkl = function reviewsFromCkl (cklData, options = {}) {
             result: result,
             resultComment: vuln.FINDING_DETAILS,
             action: action,
-            // Allow actionComments even without an action, for DISA STIG Viewer compatibility.
             actionComment: vuln.COMMENTS == "" ? null : vuln.COMMENTS,
             autoResult: false,
             status: status
@@ -208,12 +210,7 @@ const reviewsFromCkl = function reviewsFromCkl (cklData, options = {}) {
   
       return {
         reviews: vulnArray,
-        stats: {
-          notchecked: nr,
-          notapplicable: na,
-          pass: nf,
-          fail: o
-        }
+        stats: resultStats
       }
     }  
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "stigman-watcher",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "atob": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stigman-watcher",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "CLI that watches a path for STIG test result files on behalf of a STIG Manager Collection.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
- Updated the CKL parser to map <STATUS>Not_Reviewed</STATUS> where <FINDING_DETAILS> is not empty as result informational. All other `Not_Reviewed` reviews will continue to be ignored.
- Added option `--strict-revision-check` whose default is `false`. This is a behavior change from previous Watcher releases. For CKL, unless this option is set the parser will attempt to POST reviews from checklists of uninstalled STIG revisions. The API will accept reviews for Rules that are associated with an installed STIG revision, and reject reviews for Rules not associated with an installed STIG revision.