### PR TITLE
feat: update review parsing and serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ watched/
 .vscode/
 .env
 *.log
+log.json

--- a/lib/ReviewParser.js
+++ b/lib/ReviewParser.js
@@ -1,0 +1,619 @@
+(function (exports) {
+  exports.reviewsFromCkl = function (
+    {
+      data, 
+      fieldSettings,
+      allowAccept,
+      importOptions,
+      valueProcessor,
+      XMLParser
+    }) {
+      
+    if (!XMLParser) {
+      if (typeof require === 'function') {
+        const { requireXMLParser } = require('fast-xml-parser')
+        XMLParser = requireXMLParser
+      }
+      else if (typeof fxp === "object" && typeof fxp.XMLParser === 'function') {
+          XMLParser = fxp.XMLParser
+      }
+      else {
+        throw(new Error('XMLParser not found'))
+      }
+    }
+  
+    const normalizeKeys = function (input) {
+      // lowercase and remove hyphens
+      if (typeof input !== 'object') return input;
+      if (Array.isArray(input)) return input.map(normalizeKeys);
+      return Object.keys(input).reduce(function (newObj, key) {
+          let val = input[key];
+          let newVal = (typeof val === 'object') && val !== null ? normalizeKeys(val) : val;
+          newObj[key.toLowerCase().replace('-','')] = newVal;
+          return newObj;
+      }, {});
+    }
+    const resultMap = {
+      NotAFinding: 'pass',
+      Open: 'fail',
+      Not_Applicable: 'notapplicable',
+      Not_Reviewed: 'notchecked'
+    }
+    const resultStats = {
+      pass: 0,
+      fail: 0,
+      notapplicable: 0,
+      notchecked: 0,
+      notselected: 0,
+      informational: 0,
+      error: 0,
+      fixed: 0,
+      unknown: 0
+    }  
+    const parseOptions = {
+      allowBooleanAttributes: false,
+      attributeNamePrefix: "",
+      cdataPropName: "__cdata", //default is 'false'
+      ignoreAttributes: false,
+      parseTagValue: false,
+      parseAttributeValue: false,
+      removeNSPrefix: true,
+      trimValues: true,
+      tagValueProcessor: valueProcessor,
+      commentPropName: "__comment",
+      isArray: (name, jpath, isLeafNode, isAttribute) => {
+        return name === '__comment' || !isLeafNode
+      }
+    }
+    const parser = new XMLParser(parseOptions)
+    const parsed = parser.parse(data)
+  
+    if (!parsed.CHECKLIST) throw (new Error("No CHECKLIST element"))
+    if (!parsed.CHECKLIST[0].ASSET) throw (new Error("No ASSET element"))
+    if (!parsed.CHECKLIST[0].STIGS) throw (new Error("No STIGS element"))
+  
+    const comments = parsed['__comment']
+    const resultEngineCommon = comments.length ? processRootXmlComments(comments) : null
+  
+    let returnObj = {}
+    returnObj.target = processAsset(parsed.CHECKLIST[0].ASSET[0])
+    if (!returnObj.target.name) {
+      throw (new Error("No host_name in ASSET"))
+    }
+    returnObj.checklists = processIStig(parsed.CHECKLIST[0].STIGS[0].iSTIG)
+    if (returnObj.checklists.length === 0) {
+      throw (new Error("STIG_INFO element has no SI_DATA for SID_NAME == stigId"))
+    }
+    return (returnObj)
+  
+    function processAsset(assetElement) {
+      let obj =  {
+        name: assetElement.HOST_NAME,
+        description: null,
+        ip: assetElement.HOST_IP || null,
+        fqdn: assetElement.HOST_FQDN || null,
+        mac: assetElement.HOST_MAC || null,
+        noncomputing: assetElement.ASSET_TYPE === 'Non-Computing'
+      }
+      const metadata = {}
+      if (assetElement.ROLE) {
+        metadata.cklRole = assetElement.ROLE
+      }
+      if (assetElement.TECH_AREA) {
+        metadata.cklTechArea = assetElement.TECH_AREA
+      }
+      if (assetElement.WEB_OR_DATABASE === 'true') {
+        metadata.cklWebOrDatabase = 'true'
+        metadata.cklHostName = assetElement.HOST_NAME
+        if (assetElement.WEB_DB_SITE) {
+          metadata.cklWebDbSite = assetElement.WEB_DB_SITE
+        }
+        if (assetElement.WEB_DB_INSTANCE) {
+          metadata.cklWebDbInstance = assetElement.WEB_DB_INSTANCE
+        }
+      }
+      obj.metadata = metadata
+      return obj
+    }
+      
+    function processIStig(iStigElement) {
+      let checklistArray = []
+      iStigElement.forEach(iStig => {
+        let checklist = {}
+        // get benchmarkId
+        let stigIdElement = iStig.STIG_INFO[0].SI_DATA.filter( d => d.SID_NAME === 'stigid' )[0]
+        checklist.benchmarkId = stigIdElement.SID_DATA.replace('xccdf_mil.disa.stig_benchmark_', '')
+        // get revision
+        const stigVersion = iStig.STIG_INFO[0].SI_DATA.filter( d => d.SID_NAME === 'version' )[0].SID_DATA
+        let stigReleaseInfo = iStig.STIG_INFO[0].SI_DATA.filter( d => d.SID_NAME === 'releaseinfo' )[0].SID_DATA
+        const stigRelease = stigReleaseInfo.match(/Release:\s*(.+?)\s/)[1]
+        const stigRevisionStr = `V${stigVersion}R${stigRelease}`
+        checklist.revisionStr = stigRevisionStr
+  
+        if (checklist.benchmarkId) {
+          let x = processVuln(iStig.VULN)
+          checklist.reviews = x.reviews
+          checklist.stats = x.stats
+          checklistArray.push(checklist)
+        }
+      })
+      return checklistArray
+    }
+  
+    function processVuln(vulnElements) {
+      // vulnElements is an array of this object:
+      // {
+      //     COMMENTS
+      //     FINDING_DETAILS
+      //     SEVERITY_JUSTIFICATION
+      //     SEVERITY_OVERRIDE
+      //     STATUS
+      //     STIG_DATA [26]
+      // }
+  
+      let vulnArray = []
+      vulnElements?.forEach(vuln => {
+        const review = generateReview(vuln, resultEngineCommon)
+        if (review) {
+          vulnArray.push(review)
+          resultStats[review.result]++
+        }
+      })
+  
+      return {
+        reviews: vulnArray,
+        stats: resultStats
+      }
+    }
+  
+    function generateReview(vuln, resultEngineCommon) {
+      let result = resultMap[vuln.STATUS]
+      if (!result) return
+      const ruleId = getRuleIdFromVuln(vuln)
+      if (!ruleId) return
+  
+      const hasComments = !!vuln.FINDING_DETAILS || !!vuln.COMMENTS
+  
+      if (result === 'notchecked') { // unreviewed business rules
+        switch (importOptions.unreviewed) {
+          case 'never':
+            return undefined
+          case 'commented':
+            result = hasComments ? importOptions.unreviewedCommented : undefined
+            if (!result) return
+            break
+          case 'always':
+            result = hasComments ? importOptions.unreviewedCommented : 'notchecked'
+            break
+        }
+      }
+  
+      let detail = vuln.FINDING_DETAILS
+      if (!vuln.FINDING_DETAILS) {
+        switch (importOptions.emptyDetail) {
+          case 'ignore':
+            detail= null
+            break
+          case 'import':
+            detail = vuln.FINDING_DETAILS
+            break
+          case 'replace':
+            detail = 'There is no detail provided for the assessment'
+            break
+        }
+      }
+  
+      let comment = vuln.COMMENTS
+      if (!vuln.COMMENTS) {
+        switch (importOptions.emptyComment) {
+          case 'ignore':
+            comment = null
+            break
+          case 'import':
+            comment = vuln.COMMENTS
+            break
+          case 'replace':
+            comment = 'There is no comment provided for the assessment'
+            break
+        }
+      }
+  
+      const review = {
+        ruleId,
+        result,
+        detail,
+        comment
+      }
+  
+      if (resultEngineCommon) {
+        review.resultEngine = {...resultEngineCommon}
+        if (vuln['__comment']) {
+          const overrides = []
+          for (const comment of vuln['__comment']) {
+            if (comment.toString().startsWith('<Evaluate-STIG>')) {
+              let override
+              try {
+                override = parser.parse(comment)['Evaluate-STIG'][0]
+              }
+              catch(e) {
+                console.log(`Failed to parse Evaluate-STIG VULN XML comment for ${ruleId}`)
+              }
+              override = normalizeKeys(override)
+              if (override.afmod?.toLowerCase() === 'true') {
+                overrides.push({
+                  authority: override.answerfile,
+                  oldResult: resultMap[override.oldstatus] ?? 'unknown',
+                  newResult: result,
+                  remark: 'Evaluate-STIG Answer File'
+                })
+              }
+            } 
+          }
+          if (overrides.length) {
+            review.resultEngine.overrides = overrides
+          }  
+        }
+      }
+      else {
+        review.resultEngine = null
+      }
+  
+      const status = bestStatusForReview(review)
+      if (status) {
+        review.status = status
+      }
+    
+      return review
+    }
+  
+    function getRuleIdFromVuln(vuln) {
+      let ruleId
+      vuln.STIG_DATA.some(stigDatum => {
+        if (stigDatum.VULN_ATTRIBUTE == "Rule_ID") {
+          ruleId = stigDatum.ATTRIBUTE_DATA
+          return true
+        }
+      })
+      return ruleId
+    }
+  
+    function bestStatusForReview(review) {
+      if (importOptions.autoStatus === 'null') return null
+      if (importOptions.autoStatus === 'saved') return 'saved'
+  
+      let detailSubmittable = false
+      switch (fieldSettings.detail.required) {
+        case 'optional':
+          detailSubmittable = true
+          break
+        case 'findings':
+          if ((review.result !== 'fail') || (review.result === 'fail' && review.detail)) {
+            detailSubmittable = true
+          }
+          break
+        case 'always':
+          if (review.detail) {
+            detailSubmittable = true
+          }
+          break
+      } 
+  
+      let commentSubmittable = false
+      switch (fieldSettings.comment.required) {
+        case 'optional':
+          commentSubmittable = true
+          break
+        case 'findings':
+          if ((review.result !== 'fail') || (review.result === 'fail' && review.comment)) {
+            commentSubmittable = true
+          }
+          break
+        case 'always':
+          if (review.comment) {
+            commentSubmittable = true
+          }
+          break
+      }
+  
+      const resultSubmittable = review.result === 'pass' || review.result === 'fail' || review.result === 'notapplicable'
+      
+      let status = undefined
+      if (detailSubmittable && commentSubmittable && resultSubmittable) {
+        switch (importOptions.autoStatus) {
+          case 'submitted':
+            status = 'submitted'
+            break
+          case 'accepted':
+            status = allowAccept ? 'accepted' : 'submitted'
+            break
+        }
+      } 
+      else {
+        status = 'saved'
+      }
+      return status
+    }
+  
+    function processRootXmlComments(comments) {
+      let resultEngineRoot
+      for (const comment of comments) {
+        if (comment.toString().startsWith('<Evaluate-STIG>')) {
+          let esRootComment
+          try {
+            esRootComment = parser.parse(comment)['Evaluate-STIG'][0]
+          }
+          catch(e) {
+            console.log('Failed to parse Evaluate-STIG root XML comment')
+          }
+          esRootComment = normalizeKeys(esRootComment)
+          resultEngineRoot = {
+            type: 'script',
+            product: 'Evaluate-STIG',
+            version: esRootComment?.global?.[0]?.version,
+            time: esRootComment?.global?.[0]?.time,
+            checkContent: {
+              location: esRootComment?.module?.[0]?.root ?? ''
+            }
+          }
+        }
+      }
+      return resultEngineRoot || null
+    }
+  }
+  
+  exports.reviewsFromScc = function (
+    {
+      data, 
+      fieldSettings,
+      allowAccept,
+      importOptions,
+      valueProcessor,
+      scapBenchmarkMap,
+      XMLParser
+    }) {
+
+    // Parse the XML
+    const parseOptions = {
+      allowBooleanAttributes: false,
+      attributeNamePrefix: "",
+      cdataPropName: "__cdata", //default is 'false'
+      ignoreAttributes: false,
+      parseTagValue: true,
+      removeNSPrefix: true,
+      trimValues: true,
+      tagValueProcessor: valueProcessor,
+      commentPropName: "__comment",
+      isArray: (name, jpath, isLeafNode, isAttribute) => {
+        return name === 'override'
+      }
+    }
+    const parser = new XMLParser(parseOptions)  
+    let parsed = parser.parse(data)
+
+    // Baic sanity checks
+    if (!parsed.Benchmark) throw (new Error("No Benchmark element"))
+    if (!parsed.Benchmark.TestResult) throw (new Error("No TestResult element"))
+    if (!parsed.Benchmark.TestResult['target-facts']) throw (new Error("No target-facts element"))
+    if (!parsed.Benchmark.TestResult['rule-result']) throw (new Error("No rule-result element"))
+
+    // Process parsed data
+    let benchmarkId = parsed.Benchmark.id.replace('xccdf_mil.disa.stig_benchmark_', '')
+    if (scapBenchmarkMap && scapBenchmarkMap.has(benchmarkId)) {
+      benchmarkId = scapBenchmarkMap.get(benchmarkId)
+    }
+    let target = processTargetFacts(parsed.Benchmark.TestResult['target-facts'].fact)
+    if (!target.name) {
+      throw (new Error('No host_name fact'))
+    }
+
+    // resultEngine info
+    const testSystem = parsed.Benchmark.TestResult['test-system']
+    // SCC injects a CPE WFN bound to a URN
+    const m = testSystem.match(/[c][pP][eE]:\/[AHOaho]?:(.*)/)
+    let vendor, product, version
+    if (m?.[1]) {
+      ;[vendor, product, version] = m[1].split(':')
+    }
+    const resultEngineTpl = {
+      type: 'scap',
+      product,
+      version
+    }
+    const r = processRuleResults(parsed.Benchmark.TestResult['rule-result'], resultEngineTpl)
+
+    // Return object
+    return ({
+      target: target,
+      checklists: [{
+        benchmarkId: benchmarkId,
+        revisionStr: null,
+        reviews: r.reviews,
+        stats: r.stats
+      }]
+    })
+  
+    function processRuleResults(ruleResults, resultEngineTpl) {
+      const stats = {
+        pass: 0,
+        fail: 0,
+        notapplicable: 0,
+        notchecked: 0,
+        notselected: 0,
+        informational: 0,
+        error: 0,
+        fixed: 0,
+        unknown: 0
+      }
+      const reviews = []
+      for (const ruleResult of ruleResults) {
+        const review = generateReview(ruleResult, resultEngineTpl)
+        if (review) {
+          reviews.push(review)
+          stats[review.result]++
+        }
+      }
+      return { reviews, stats }
+    }
+
+    function generateReview(ruleResult, resultEngineCommon) {
+      let result = ruleResult.result
+      if (!result) return
+      const ruleId = ruleResult.idref.replace('xccdf_mil.disa.stig_rule_', '')
+      if (!ruleId) return
+
+      const hasComments = false // or look for <remark>
+
+      if (result !== 'pass' && result !== 'fail' && result !== 'notapplicable') { // unreviewed business rules
+        switch (importOptions.unreviewed) {
+          case 'never':
+            return undefined
+          case 'commented':
+            result = hasComments ? importOptions.unreviewedCommented : undefined
+            if (!result) return
+            break
+          case 'always':
+              result = hasComments ? importOptions.unreviewedCommented : 'notchecked'
+              break
+        }
+      }
+
+      let resultEngine
+      if (resultEngineCommon) {
+        // build the resultEngine value
+        resultEngine = {
+          time: new Date(ruleResult.time), 
+          ...resultEngineCommon
+        }
+        // handle check-content-ref, if it exists
+        const checkContentHref = ruleResult?.check?.['check-content-ref']?.href?.replace('#scap_mil.disa.stig_comp_','')
+        const checkContentName = ruleResult?.check?.['check-content-ref']?.name?.replace('oval:mil.disa.stig.','')
+        if (checkContentHref || checkContentName) {
+          resultEngine.checkContent = {
+            location: checkContentHref,
+            component: checkContentName
+          }
+        }
+        
+        if (ruleResult.override?.length) { //overrides
+          const overrides = []
+          for (const override of ruleResult.override) {
+            overrides.push({
+              authority: override.authority,
+              oldResult: override['old-result'],
+              newResult: override['new-result'],
+              remark: override['remark']
+            })
+          }
+          if (overrides.length) {
+            resultEngine.overrides = overrides
+          }  
+        }
+      }
+
+      const replacementText = `Result was reported by product "${resultEngine?.product}" version ${resultEngine?.version} at ${resultEngine?.time?.toISOString()} using check content "${resultEngine?.checkContent?.location}"`
+
+      let detail
+      switch (importOptions.emptyDetail) {
+        case 'ignore':
+          detail= null
+          break
+        case 'import':
+          detail = ''
+          break
+        case 'replace':
+          detail = replacementText
+          break
+      }
+
+      let comment
+      switch (importOptions.emptyComment) {
+        case 'ignore':
+          comment = null
+          break
+        case 'import':
+          comment = ''
+          break
+        case 'replace':
+          comment = replacementText
+          break
+      }
+
+      const review = {
+        ruleId,
+        result,
+        resultEngine,
+        detail,
+        comment
+      }
+
+      const status = bestStatusForReview(review)
+      if (status) {
+        review.status = status
+      }
+      
+      return review
+    }
+  
+    function bestStatusForReview(review) {
+      if (importOptions.autoStatus === 'null') return undefined
+      if (importOptions.autoStatus === 'saved') return 'saved'
+  
+      const fields = ['detail', 'comment']
+      let commentsSubmittable
+      for (const field of fields) {
+        switch (fieldSettings[field].required) {
+          case 'optional':
+            commentsSubmittable = true
+            break
+          case 'findings':
+            commentsSubmittable = ((review.result !== 'fail') || (review.result === 'fail' && review[field]))
+            break
+          case 'always':
+            commentsSubmittable = !!review[field]
+            break
+          }
+        if (!commentsSubmittable) break // can end loop if commentsSubmittable becomes false
+      }
+  
+      const resultSubmittable = review.result === 'pass' || review.result === 'fail' || review.result === 'notapplicable'
+      
+      let status = undefined
+      if (commentsSubmittable && resultSubmittable) {
+        switch (importOptions.autoStatus) {
+          case 'submitted':
+            status = 'submitted'
+            break
+          case 'accepted':
+            status = allowAccept ? 'accepted' : 'submitted'
+            break
+        }
+      } 
+      else {
+        status = 'saved'
+      }
+      return status
+    }
+
+    function processTargetFacts(facts) {
+      let target = {}
+      facts.forEach(fact => {
+        if (fact['#text']) {
+          let name = fact.name.replace('urn:scap:fact:asset:identifier:', '')
+          name = name === 'ipv4' ? 'ip' : name
+          target[name] = fact['#text'] 
+        }
+      })
+      const {ip, host_name, fqdn, mac, ...metadata} = target
+      return {
+        name: host_name,
+        description: '',
+        ip: ip,
+        mac: mac,
+        fqdn: fqdn,
+        noncomputing: false,
+        metadata: metadata
+      }
+    }
+  }
+  
+}) (typeof exports === 'undefined'? this['ReviewParser'] = {} : exports)

--- a/lib/api.js
+++ b/lib/api.js
@@ -3,95 +3,65 @@ const got = require('got')
 const config = require('./args')
 const auth = require('./auth')
 const { logger, getSymbol } = require('./logger')
+const { serializeError } = require('serialize-error')
 
-module.exports.getScapBenchmarkMap = async function () {
-  let response
+const cache = {
+  collection: null,
+  assets: null,
+  user: null,
+  definition: null,
+  scapBenchmarkMap: null,
+  stigs: null
+}
+
+module.exports.cache = cache
+
+async function apiGet(endpoint, authenticate = true) {
   try {
-    await auth.getToken()
-    response = await got.get(`${config.api}/stigs/scap-maps`, {
-      headers: {
-        Authorization: `Bearer ${auth.tokens.access_token}`
-      },
+    const options = {
       responseType: 'json'
-    })
+    }
+    if (authenticate) {
+      await auth.getToken()
+      options.headers = {
+        Authorization: `Bearer ${auth.tokens.access_token}`
+      }
+    }
+    const response = await got.get(`${config.api}${endpoint}`, options)
     logResponse (response )
-    return new Map(response.body.map(apiScapMap => [apiScapMap.scapBenchmarkId, apiScapMap.benchmarkId]))
+    return response.body
   }
   catch (e) {
     e.component = 'api'
+    logError(e)
     throw (e)
   }
+} 
+
+module.exports.getScapBenchmarkMap = async function () {
+  const response = await apiGet('/stigs/scap-maps')
+  cache.scapBenchmarkMap = new Map(response.map(apiScapMap => [apiScapMap.scapBenchmarkId, apiScapMap.benchmarkId]))
+  return cache.scapBenchmarkMap
 }
 
 module.exports.getDefinition = async function (jsonPath) {
-  let response
-  try {
-    response = await got.get(`${config.api}/op/definition${jsonPath ? '?jsonpath=' + encodeURIComponent(jsonPath) : ''}`, {
-      responseType: 'json'
-    })
-    logResponse (response )
-    return response.body
-  }
-  catch (e) {
-    e.component = 'api'
-    throw (e)
-  }
+  cache.definition = await apiGet(`/op/definition${jsonPath ? '?jsonpath=' + encodeURIComponent(jsonPath) : ''}`, false) 
+  return cache.definition
 }
 
 module.exports.getCollection = async function (collectionId) {
-  let response
-  try {
-    await auth.getToken()
-    response = await got.get(`${config.api}/collections/${collectionId}`, {
-      headers: {
-        Authorization: `Bearer ${auth.tokens.access_token}`
-      },
-      responseType: 'json'
-    })
-    logResponse (response )
-    return response.body
-  }
-  catch (e) {
-    e.component = 'api'
-    throw (e)
-  }
+  cache.collection = await apiGet(`/collections/${collectionId}`)
+  return cache.collection
 }
 
 module.exports.getCollectionAssets = async function (collectionId) {
-  let response
-  try {
-    await auth.getToken()
-    response = await got.get(`${config.api}/assets?collectionId=${collectionId}&projection=stigs`, {
-      headers: {
-        Authorization: `Bearer ${auth.tokens.access_token}`
-      },
-      responseType: 'json'
-    })
-    logResponse (response )
-    return response.body
-  }
-  catch (e) {
-    e.component = 'api'
-    throw (e)
-  }
+  cache.assets = await apiGet(`/assets?collectionId=${collectionId}&projection=stigs`)
+  return cache.assets
 }
 
 module.exports.getInstalledStigs = async function () {
-  try {
-    await auth.getToken()
-    const response = await got.get(`${config.api}/stigs`, {
-      headers: {
-        Authorization: `Bearer ${auth.tokens.access_token}`
-      },
-      responseType: 'json'
-    })
-    logResponse(response)
-    return response.body
-  }
-  catch (e) {
-    e.component = 'api'
-    throw (e)
-  }
+  cache.stigs = await apiGet('/stigs')
+  return cache.stigs
 }
 
 module.exports.createOrGetAsset = async function (asset) {
@@ -155,6 +125,19 @@ module.exports.postReviews = async function (collectionId, assetId, reviews) {
   }
 }
 
+module.exports.getUser = async function () {
+  cache.user = await apiGet('/user')
+  return cache.user
+}
+
+module.exports.canUserAccept = function () {
+  const curUser = cache.user
+  const apiCollection = cache.collection
+  const userGrant = curUser.collectionGrants.find( i => i.collection.collectionId === apiCollection.collectionId )?.accessLevel
+  const allowAccept = apiCollection.settings.status.canAccept && (userGrant >= apiCollection.settings.status.minAcceptGrant)
+  return allowAccept
+}
+
 function logResponse (response) {
   logger.http({
     component: 'api',
@@ -180,5 +163,20 @@ function logResponse (response) {
       body: response.body
     }
   })
-
 }
+
+function logError (e) {
+  logger.error({
+    component: 'api',
+    message: 'query error',
+    request: {
+      method: e.request?.options?.method,
+      url: e.request?.requestUrl
+    } ,
+    response: {
+      status: e.response?.statusCode,
+      body: e.response?.body
+    }
+  })
+}
+

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -9,7 +9,7 @@ let self = this
 
 self.url = `${config.authority}/protocol/openid-connect/token`
 self.threshold = 10
-self.scope = 'openid stig-manager:collection stig-manager:stig:read'
+self.scope = 'openid stig-manager:collection stig-manager:stig:read stig-manager:user:read'
 self.key = config.clientKey
 self.authenticateFn = config.clientKey ? authenticateSignedJwt : authenticateClientSecret
 self.authentication = config.clientKey ? 'signed-jwt' : 'client-secret'

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,346 +1,37 @@
-const parser = require('fast-xml-parser')
+const api = require ('./api')
+const { XMLParser } = require('fast-xml-parser')
+const ReviewParser = require('./ReviewParser')
 const Queue = require('better-queue')
 const { logger } = require('./logger')
 const cargo = require('./cargo')
 const fs = require('fs').promises
-const tagValueProcessor = require('he').decode
-const api = require('./api')
-
-// const parseResult = {
-//   type: 'CKL' || 'XCCDF',
-//   target: {
-//     name: 'string',
-//     description: 'string',
-//     ip: 'string',
-//     noncomputing: 'string',
-//     fqdn: 'string',
-//     mac: 'string',
-//     metadata: {}
-//   },
-//   checklists: [
-//     {
-//       benchmrkId: 'string',
-//       revisionStr: 'string',
-//       reviews: [
-//         {
-//           ruleId: '',
-//           result: '',
-//           resultComment: '',
-//           action: '' || null,
-//           actionComment: '' || null,
-//           autoResult: false,
-//           status: ''
-//         }
-//       ],
-//       stats: {
-//          pass: 0,
-//          fail: 0,
-//          notapplicable: 0,
-//          notchecked: 0,
-//          notselected: 0,
-//          informational: 0,
-//          error: 0,
-//          fixed: 0,
-//          unknown: 0
-//       }
-//     }
-//   ]
-// }
-
-const reviewsFromCkl = function reviewsFromCkl (cklData, options = {}, fieldSettings) {
-  options.ignoreNr = !!options.ignoreNr
-  const fastparseOptions = {
-    attributeNamePrefix: "",
-    ignoreAttributes: false,
-    ignoreNameSpace: true,
-    allowBooleanAttributes: false,
-    parseNodeValue: false,
-    parseAttributeValue: false,
-    trimValues: true,
-    cdataTagName: "__cdata", //default is 'false'
-    cdataPositionChar: "\\c",
-    localeRange: "", //To support non english character in tag/attribute values.
-    parseTrueNumberOnly: false,
-    arrayMode: true, //"strict"
-    tagValueProcessor: val => tagValueProcessor(val)
+const he = require('he')
+const valueProcessor = function (tagName, tagValue, jPath, hasAttributes, isLeafNode) {
+  he.decode(tagValue)
+}
+const defaultImportOptions = {
+  autoStatus: 'saved',
+  unreviewed: 'commented',
+  unreviewedCommented: 'informational',
+  emptyDetail: 'replace',
+  emptyComment: 'ignore',
+  allowCustom: true
+}
+function safeJSONParse (value) {
+  try {
+    return JSON.parse(value)
   }
-  let parsed = parser.parse(cklData, fastparseOptions)
-
-  if (!parsed.CHECKLIST) throw (new Error("No CHECKLIST element"))
-  if (!parsed.CHECKLIST[0].ASSET) throw (new Error("No ASSET element"))
-  if (!parsed.CHECKLIST[0].STIGS) throw (new Error("No STIGS element"))
-
-  let returnObj = {}
-  returnObj.target = processAsset(parsed.CHECKLIST[0].ASSET[0])
-  if (!returnObj.target.name) {
-    throw (new Error("No host_name in ASSET"))
-  }
-  returnObj.checklists = processIStig(parsed.CHECKLIST[0].STIGS[0].iSTIG)
-  if (returnObj.checklists.length === 0) {
-    throw (new Error("STIG_INFO element has no SI_DATA for SID_NAME == stigId"))
-  }
-  return (returnObj)
-
-  function processAsset(assetElement) {
-    let obj =  {
-      name: assetElement.HOST_NAME,
-      description: null,
-      ip: assetElement.HOST_IP || null,
-      fqdn: assetElement.HOST_FQDN || null,
-      mac: assetElement.HOST_MAC || null,
-      noncomputing: assetElement.ASSET_TYPE === 'Non-Computing'
-    }
-    const metadata = {}
-    if (assetElement.ROLE) {
-      metadata.cklRole = assetElement.ROLE
-    }
-    if (assetElement.TECH_AREA) {
-      metadata.cklTechArea = assetElement.TECH_AREA
-    }
-    if (assetElement.WEB_OR_DATABASE === 'true') {
-      metadata.cklWebOrDatabase = 'true'
-      metadata.cklHostName = assetElement.HOST_NAME
-      if (assetElement.WEB_DB_SITE) {
-        metadata.cklWebDbSite = assetElement.WEB_DB_SITE
-      }
-      if (assetElement.WEB_DB_INSTANCE) {
-        metadata.cklWebDbInstance = assetElement.WEB_DB_INSTANCE
-      }
-    }
-    obj.metadata = metadata
-    return obj
-  }
-    
-  function processIStig(iStigElement) {
-    let checklistArray = []
-    iStigElement.forEach(iStig => {
-      let checklist = {}
-      // get benchmarkId
-      let stigIdElement = iStig.STIG_INFO[0].SI_DATA.filter( d => d.SID_NAME === 'stigid' )[0]
-      checklist.benchmarkId = stigIdElement.SID_DATA.replace('xccdf_mil.disa.stig_benchmark_', '')
-      // get revision
-      const stigVersion = iStig.STIG_INFO[0].SI_DATA.filter( d => d.SID_NAME === 'version' )[0].SID_DATA
-      let stigReleaseInfo = iStig.STIG_INFO[0].SI_DATA.filter( d => d.SID_NAME === 'releaseinfo' )[0].SID_DATA
-      const stigRelease = stigReleaseInfo.match(/Release:\s*(.+?)\s/)[1]
-      const stigRevisionStr = `V${stigVersion}R${stigRelease}`
-      checklist.revisionStr = stigRevisionStr
-
-      if (checklist.benchmarkId) {
-        let x = processVuln(iStig.VULN)
-        checklist.reviews = x.reviews
-        checklist.stats = x.stats
-        checklistArray.push(checklist)
-      }
-    })
-    return checklistArray
-  }
-
-  function processVuln(vulnElements) {
-    // vulnElements is an array of this object:
-    // {
-    //     COMMENTS
-    //     FINDING_DETAILS
-    //     SEVERITY_JUSTIFICATION
-    //     SEVERITY_OVERRIDE
-    //     STATUS
-    //     STIG_DATA [26]
-    // }
-
-    const resultMap = {
-      NotAFinding: 'pass',
-      Open: 'fail',
-      Not_Applicable: 'notapplicable',
-      Not_Reviewed: 'notchecked'
-    }
-    const resultStats = {
-      pass: 0,
-      fail: 0,
-      notapplicable: 0,
-      notchecked: 0,
-      notselected: 0,
-      informational: 0,
-      error: 0,
-      fixed: 0,
-      unknown: 0
-    }  
-    let vulnArray = []
-    vulnElements?.forEach(vuln => {
-      let result = resultMap[vuln.STATUS]
-      if (result) {
-        if (result === 'notchecked' && (vuln.FINDING_DETAILS || vuln.COMMENTS)) result = 'informational'
-        resultStats[result]++
-        if (result === 'notchecked' && options.ignoreNr) return
-        let ruleId
-        vuln.STIG_DATA.some(stigDatum => {
-          if (stigDatum.VULN_ATTRIBUTE == "Rule_ID") {
-            ruleId = stigDatum.ATTRIBUTE_DATA
-            return true
-          }
-        })
-        if (!ruleId) return
-        // let status = bestStatusForVuln(result, vuln.FINDING_DETAILS, vuln.COMMENTS, fieldSettings)
-        vulnArray.push({
-          ruleId: ruleId,
-          result: result,
-          detail: options.replaceText ? vuln.FINDING_DETAILS : vuln.FINDING_DETAILS || null,
-          comment: options.replaceText ? vuln.COMMENTS : vuln.COMMENTS || null,
-          autoResult: false,
-          // status: status
-        })    
-      }
-    })
-
-    return {
-      reviews: vulnArray,
-      stats: resultStats
-    }
-  }
-
-  function bestStatusForVuln(result, detail, comment, fieldSettings) {
-    let detailSubmittable = false
-    switch (fieldSettings.detailRequired) {
-      case 'optional':
-        detailSubmittable = true
-        break
-      case 'findings':
-        if ((result !== 'fail') || (result === 'fail' && detail)) {
-          detailSubmittable = true
-        }
-        break
-      case 'always':
-        if (detail) {
-          detailSubmittable = true
-        }
-        break
-    } 
-    let commentSubmittable = false
-    switch (fieldSettings.commentRequired) {
-      case 'optional':
-        commentSubmittable = true
-        break
-      case 'findings':
-        if ((result !== 'fail') || (result === 'fail' && comment)) {
-          commentSubmittable = true
-        }
-        break
-      case 'always':
-        if (comment) {
-          commentSubmittable = true
-        }
-        break
-    } 
-    return detailSubmittable && commentSubmittable ? 'submitted' : 'saved'
+  catch (e) {
+    return undefined
   }
 }
+function canUserAccept () {
+  if (!api.cache.user) return false
 
-const reviewsFromScc = function (sccFileContent, options = {}) {
-  options.ignoreNotChecked = !!options.ignoreNotChecked
-  // Parse the XML
-  const parseOptions = {
-    attributeNamePrefix: "",
-    ignoreAttributes: false,
-    ignoreNameSpace: true,
-    allowBooleanAttributes: false,
-    parseNodeValue: true,
-    parseAttributeValue: true,
-    trimValues: true,
-    cdataTagName: "__cdata", //default is 'false'
-    cdataPositionChar: "\\c",
-    localeRange: "", //To support non english character in tag/attribute values.
-    parseTrueNumberOnly: false,
-    arrayMode: false //"strict"
-  }
-  let parsed = parser.parse(sccFileContent, parseOptions)
-
-  // Baic sanity checks
-  if (!parsed.Benchmark) {
-    throw (new Error("No Benchmark element"))
-  }
-  if (!parsed.Benchmark.TestResult) {
-    throw (new Error("No TestResult element"))
-  }
-  if (!parsed.Benchmark.TestResult['target-facts']) {
-    throw (new Error("No target-facts element"))
-  }
-  if (!parsed.Benchmark.TestResult['rule-result']) {
-    throw (new Error("No rule-result element"))
-  }
-
-  // Process parsed data
-  let benchmarkId = parsed.Benchmark.id.replace('xccdf_mil.disa.stig_benchmark_', '')
-  if (options.scapBenchmarkMap && options.scapBenchmarkMap.has(benchmarkId)) {
-    benchmarkId = options.scapBenchmarkMap.get(benchmarkId)
-  }
-  let target = processTargetFacts(parsed.Benchmark.TestResult['target-facts'].fact)
-  if (!target.name) {
-    throw (new Error('No host_name fact'))
-  }
-  let x = processRuleResults(parsed.Benchmark.TestResult['rule-result'])
-
-  // Return object
-  return ({
-    target: target,
-    checklists: [{
-      benchmarkId: benchmarkId,
-      revisionStr: null,
-      reviews: x.reviews,
-      stats: x.stats
-    }]
-  })
-
-  function processRuleResults(ruleResults) {
-    const resultStats = {
-      pass: 0,
-      fail: 0,
-      notapplicable: 0,
-      notchecked: 0,
-      notselected: 0,
-      informational: 0,
-      error: 0,
-      fixed: 0,
-      unknown: 0
-    }
-    let reviews = []
-    ruleResults.forEach(ruleResult => {
-      resultStats[ruleResult.result]++
-      if (ruleResult.result) {
-        if ( ruleResult.result === 'notchecked' && options.ignoreNotChecked ) return
-        reviews.push({
-          ruleId: ruleResult.idref.replace('xccdf_mil.disa.stig_rule_', ''),
-          result: ruleResult.result,
-          detail: `SCC Reviewed at ${ruleResult.time}`,
-          comment: null,
-          autoResult: true,
-          status: 'saved'
-        })  
-      }
-    })
-    return {
-      reviews: reviews,
-      stats: resultStats
-    }
-  }
-
-  function processTargetFacts(facts) {
-    let target = {}
-    facts.forEach(fact => {
-      if (fact['#text']) {
-        let name = fact.name.replace('urn:scap:fact:asset:identifier:', '')
-        name = name === 'ipv4' ? 'ip' : name
-        target[name] = fact['#text'] 
-      }
-    })
-    const {ip, host_name, fqdn, mac, ...metadata} = target
-    return {
-      name: host_name,
-      description: '',
-      ip: ip,
-      mac: mac,
-      fqdn: fqdn,
-      noncomputing: false,
-      metadata: metadata
-    }
-  }
+  const apiCollection = api.cache.collection
+  const userGrant = api.cache.user.collectionGrants.find( i => i.collection.collectionId === apiCollection.collectionId )?.accessLevel
+  
+  return apiCollection.settings.status.canAccept && (userGrant >= apiCollection.settings.status.minAcceptGrant)
 }
 
 async function parseFileAndEnqueue (file, cb) {
@@ -349,19 +40,35 @@ async function parseFileAndEnqueue (file, cb) {
     const extension = file.substring(file.lastIndexOf(".") + 1)
     let parseFn, type
     if (extension.toLowerCase() === 'ckl') {
-      parseFn = reviewsFromCkl
+      parseFn = ReviewParser.reviewsFromCkl
       type = 'CKL'
     }
     else if (extension.toLowerCase() === 'xml') {
-      parseFn = reviewsFromScc
+      parseFn = ReviewParser.reviewsFromScc
       type = "XCCDF"
     }
     else {
       throw (`Ignored unknown extension`)
     }
+    // ReviewParser params
     const data = await fs.readFile(file)
-    logger.verbose({component: component, message: `parse started`, file: file})
-    let parseResult = parseFn(data.toString(), {ignoreNr: true, ignoreNotChecked: true, scapBenchmarkMap: api.scapBenchmarkMap})
+    logger.verbose({component: component, message: `readFile succeeded`, file: file})
+
+    const apiCollection = api.cache.collection
+    const importOptions = safeJSONParse(apiCollection.metadata?.importOptions) ?? defaultImportOptions
+    const fieldSettings = apiCollection.settings.fields
+    const allowAccept = canUserAccept()
+    const scapBenchmarkMap = api.cache.scapBenchmarkMap
+
+    let parseResult = parseFn({
+      data,
+      importOptions,
+      fieldSettings,
+      allowAccept,
+      valueProcessor,
+      XMLParser,
+      scapBenchmarkMap
+    })
     parseResult.file = file
     logger.debug({component: component, message: `parse results`, results: parseResult})
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "commander": "^7.2.0",
         "dotenv": "^8.2.0",
         "fast-glob": "^3.2.5",
-        "fast-xml-parser": "^3.19.0",
+        "fast-xml-parser": "^4.0.7",
         "got": "^11.8.2",
         "he": "^1.2.0",
         "jsonwebtoken": "^8.5.1",
@@ -392,14 +392,14 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
-      "integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.7.tgz",
+      "integrity": "sha512-dMtibyus3kC7nbxj1CpVtysLzO13UOAZEFAb5vpQg3T4O6qvetmSePpXKFx5KPNCHKoGwjtgjfF5DOyn7s1ylQ==",
       "dependencies": {
-        "strnum": "^1.0.4"
+        "strnum": "^1.0.5"
       },
       "bin": {
-        "xml2js": "cli.js"
+        "fxparser": "src/cli/cli.js"
       },
       "funding": {
         "type": "paypal",
@@ -1012,9 +1012,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.4.tgz",
-      "integrity": "sha512-lMzNMfDpaQOLt4B2mEbfzYS0+T7dvCXeojnlGf6f1AygvWDMcWyXYaLbyICfjVu29sErR8fnRagQfBW/N/hGgw=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/text-hex": {
       "version": "1.0.0",
@@ -1423,11 +1423,11 @@
       }
     },
     "fast-xml-parser": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
-      "integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.7.tgz",
+      "integrity": "sha512-dMtibyus3kC7nbxj1CpVtysLzO13UOAZEFAb5vpQg3T4O6qvetmSePpXKFx5KPNCHKoGwjtgjfF5DOyn7s1ylQ==",
       "requires": {
-        "strnum": "^1.0.4"
+        "strnum": "^1.0.5"
       }
     },
     "fastq": {
@@ -1873,9 +1873,9 @@
       }
     },
     "strnum": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.4.tgz",
-      "integrity": "sha512-lMzNMfDpaQOLt4B2mEbfzYS0+T7dvCXeojnlGf6f1AygvWDMcWyXYaLbyICfjVu29sErR8fnRagQfBW/N/hGgw=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "text-hex": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "commander": "^7.2.0",
     "dotenv": "^8.2.0",
     "fast-glob": "^3.2.5",
-    "fast-xml-parser": "^3.19.0",
+    "fast-xml-parser": "^4.0.7",
     "got": "^11.8.2",
     "he": "^1.2.0",
     "jsonwebtoken": "^8.5.1",


### PR DESCRIPTION
Resolves #20 
Resolves #18 
Resolves #11 
Resolves #10

- Minimum STIG Manager API version is updated from 1.1.0 => 1.2.7

- Adds support for the `resultEngine` property of Review 

- The serializers now attempt to fetch configuration options from `Collection.metadata.importOptions`. If this metadata property is absent, a default configuration object which mimics previous serialization behavior is used. Support for configuring custom options will be considered in future PRs. See the STIG Manager API definition for property descriptions.

```
 const defaultImportOptions = {
  autoStatus: 'saved',
  unreviewed: 'commented',
  unreviewedCommented: 'informational',
  emptyDetail: 'replace',
  emptyComment: 'ignore',
  allowCustom: false
}
```

- The serializers now reference Collection field and status settings when calculating whether an `autoStatus` setting can be honored.

- Watcher now requests scope `stig-manager:user:read` from the OIDC Provider. If Watcher's token does not include this scope, Watcher is unable to honor the Collection property `metadata.importOptions.autoStatus = 'accepted'` (See below).

- The serializers will *optionally* reference Collection Grant settings in order to calculate whether an `autoStatus = "accepted"` setting can be honored. Watcher now attempts to call API endpoint `/user` to learn the Watcher userId. If Watcher is denied access to this endpoint (most likely because Watcher's token is missing scope `stig-manager:user:read`) it will not attempt to set `accepted` status on any Reviews.

- To avoid Collection settings and metadata from becoming excessively stale, Watcher now makes calls to `/collection/{collectionId}` and `/user` at ten minute intervals. Support for configuring this interval will be considered in future PRs, as will alternative approaches to polling.

