### PR TITLE
fix: eval-stig module name element

### DIFF
--- a/lib/ReviewParser.js
+++ b/lib/ReviewParser.js
@@ -352,7 +352,7 @@
             version: esRootComment?.global?.[0]?.version,
             time: esRootComment?.global?.[0]?.time,
             checkContent: {
-              location: esRootComment?.module?.[0]?.root ?? ''
+              location: esRootComment?.module?.[0]?.name ?? ''
             }
           }
         }


### PR DESCRIPTION
Eval-STIG team settled on `<module><name>` instead of `<module><root>`