### PR TITLE
fix: handle CKL with no root XML comment

### DIFF
--- a/lib/ReviewParser.js
+++ b/lib/ReviewParser.js
@@ -75,7 +75,7 @@
     if (!parsed.CHECKLIST[0].STIGS) throw (new Error("No STIGS element"))
   
     const comments = parsed['__comment']
-    const resultEngineCommon = comments.length ? processRootXmlComments(comments) : null
+    const resultEngineCommon = comments?.length ? processRootXmlComments(comments) : null
   
     let returnObj = {}
     returnObj.target = processAsset(parsed.CHECKLIST[0].ASSET[0])

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stigman-watcher",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stigman-watcher",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "license": "MIT",
       "dependencies": {
         "atob": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stigman-watcher",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "CLI that watches a path for STIG test result files on behalf of a STIG Manager Collection.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
CKL serializer was failing when parsing CKL with no root XML comment. Added the optional chaining operator.

Also bumped version to 1.2.6