### PR TITLE
Create revision string only if STIG version and Release info supports it.

### DIFF
--- a/lib/ReviewParser.js
+++ b/lib/ReviewParser.js
@@ -123,13 +123,14 @@
       iStigElement.forEach(iStig => {
         let checklist = {}
         // get benchmarkId
-        let stigIdElement = iStig.STIG_INFO[0].SI_DATA.filter( d => d.SID_NAME === 'stigid' )[0]
+        let stigIdElement = iStig.STIG_INFO[0].SI_DATA.filter( d => d.SID_NAME === 'stigid' )?.[0]
         checklist.benchmarkId = stigIdElement.SID_DATA.replace('xccdf_mil.disa.stig_benchmark_', '')
-        // get revision
-        const stigVersion = iStig.STIG_INFO[0].SI_DATA.filter( d => d.SID_NAME === 'version' )[0].SID_DATA
-        let stigReleaseInfo = iStig.STIG_INFO[0].SI_DATA.filter( d => d.SID_NAME === 'releaseinfo' )[0].SID_DATA
-        const stigRelease = stigReleaseInfo.match(/Release:\s*(.+?)\s/)[1]
-        const stigRevisionStr = `V${stigVersion}R${stigRelease}`
+        // get revision data. Extract digits from version and release fields to create revisionStr, if possible.
+        const stigVersionData = iStig.STIG_INFO[0].SI_DATA.filter( d => d.SID_NAME === 'version' )?.[0].SID_DATA
+        let stigVersion = stigVersionData.match(/(\d+)/)?.[1]
+        let stigReleaseInfo = iStig.STIG_INFO[0].SI_DATA.filter( d => d.SID_NAME === 'releaseinfo' )?.[0].SID_DATA
+        const stigRelease = stigReleaseInfo.match(/Release:\s*(.+?)\s/)?.[1]
+        const stigRevisionStr = stigVersion && stigRelease ? `V${stigVersion}R${stigRelease}` : null
         checklist.revisionStr = stigRevisionStr
   
         if (checklist.benchmarkId) {
@@ -399,7 +400,7 @@
     const parser = new XMLParser(parseOptions)  
     let parsed = parser.parse(data)
 
-    // Baic sanity checks
+    // Basic sanity checks
     if (!parsed.Benchmark) throw (new Error("No Benchmark element"))
     if (!parsed.Benchmark.TestResult) throw (new Error("No TestResult element"))
     if (!parsed.Benchmark.TestResult['target']) throw (new Error("No target element"))


### PR DESCRIPTION
Create revision string only if STIG version and Release info supports it. Otherwise null.
Matches "Parsers.js" in the stig-manager repo.