### PR TITLE
fix: case insensitive matching

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -53,8 +53,8 @@ class TaskObject {
     const matchedByCklHostname = this.mappedCklHostnames.get(target.metadata.cklHostName.toLowerCase())
     if (!matchedByCklHostname) return null
     const matchedByAllCklMetadata = matchedByCklHostname.find(
-      asset => asset.metadata.cklWebDbInstance === target.metadata.cklWebDbInstance
-        && asset.metadata.cklWebDbSite === target.metadata.cklWebDbSite)
+      asset => asset.metadata.cklWebDbInstance?.toLowerCase() === target.metadata.cklWebDbInstance?.toLowerCase()
+        && asset.metadata.cklWebDbSite?.toLowerCase() === target.metadata.cklWebDbSite?.toLowerCase())
     if (!matchedByAllCklMetadata) return null
     return matchedByAllCklMetadata
   }


### PR DESCRIPTION
Resolves #40 

In `lib/cargo.js`, normalizes the cklWebDb* property values to lowercase when attempting to match an existing Asset.