### PR TITLE
hotfix: call TaskObject with an option property; bump to 1.4.1

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -35,7 +35,7 @@ async function writer ( taskAsset ) {
       })
       r.stigs = r.stigs.map( stig => stig.benchmarkId )
       logger.info({ component: component, message: `STIG assignments updated`, 
-      asset: { assetId: r.assetId, name: r.name, stigs: r.stigs } })
+        asset: { assetId: r.assetId, name: r.name, stigs: r.stigs } })
     }
 
     // POST reviews
@@ -97,7 +97,7 @@ async function resultsHandler( parsedResults, cb ) {
     logger.info({component: component, message: `batch started`, batchId: batchId, size: parsedResults.length})
     const apiAssets = await api.getCollectionAssets(config.collectionId)
     const apiStigs = await api.getInstalledStigs()
-    const tasks = new TaskObject ({ parsedResults, apiAssets, apiStigs })
+    const tasks = new TaskObject ({ parsedResults, apiAssets, apiStigs, options:config })
     for ( const taskAsset of tasks.taskAssets.values() ) {
       await writer( taskAsset )
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stigman-watcher",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stigman-watcher",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "atob": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stigman-watcher",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "CLI that watches a path for STIG test result files on behalf of a STIG Manager Collection.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
TaskObject was being instantiated without the necessary `options` property. Fixed and incremented the version to 1.4.1