### PR TITLE
Chore: Update github actions to v4

### DIFF
--- a/.github/workflows/build-binary-artifacts.yml
+++ b/.github/workflows/build-binary-artifacts.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - update-actions-versions
     paths:
       - "lib/**"
       - "index.js"
@@ -18,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
@@ -65,7 +66,7 @@ jobs:
           fi
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() 
         with:
           name: binary-artifacts

--- a/.github/workflows/build-binary-artifacts.yml
+++ b/.github/workflows/build-binary-artifacts.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - update-actions-versions
     paths:
       - "lib/**"
       - "index.js"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - update-actions-versions
     paths:
       - "lib/**"
       - "index.js"
@@ -13,7 +12,6 @@ on:
   push:
     branches:
       - main
-      - update-actions-versions
     paths:
       - "lib/**"
       - "index.js"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - update-actions-versions
     paths:
       - "lib/**"
       - "index.js"
@@ -12,6 +13,7 @@ on:
   push:
     branches:
       - main
+      - update-actions-versions
     paths:
       - "lib/**"
       - "index.js"
@@ -26,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Important to fetch all history for accurate blame information
       - name: Analyze Watcher with SonarCloud

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
         - main
+        - update-actions-versions
     paths:
         - "lib/**"
         - "index.js"
         - "test/**"
+        - ".github/workflows/unit-testing.yml"
   pull_request:
     branches:
         - main
@@ -15,17 +17,17 @@ on:
         - "lib/**"
         - "index.js"
         - "test/**"
-
+        - ".github/workflows/unit-testing.yml"
 jobs:
   build_test:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Node.js 
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: "20.x"
     - name: Install app dependencies
       run: npm ci
     - name: Create .env file
@@ -33,7 +35,7 @@ jobs:
     - name: Run tests
       run: npm test
     - name: Upload coverage to github
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
         name: coverage

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
         - main
-        - update-actions-versions
     paths:
         - "lib/**"
         - "index.js"


### PR DESCRIPTION
This pull request upgrades the Node.js version for actions within this repository to use Node.js 20. Additionally, it modifies the workflow by incorporating unit-testing.yml into the 'on:' trigger, ensuring the workflow initiates whenever there are updates to it.

The following actions were changed to version 4:

actions/checkout
actions/upload-artifact
actions/setup-node