### PR TITLE
fix: static version string in args.js

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -1,3 +1,4 @@
+const version = '1.4.2'
 
 import help_default from './help.js'
 help_default()
@@ -12,19 +13,8 @@ import { createPrivateKey } from 'crypto'
 const prompt = promptSync({ sigint:true })
 const component = 'args'
 
-function getVersion() {
-  try {
-    const packageJsonText = readFileSync('./package.json', 'utf8')
-    return JSON.parse(packageJsonText).version
-  } 
-  catch (error) {
-    console.error('Error reading package.json:', error)
-  }
-}
-
 let configValid = true
 
-const version = getVersion()
 
 // Use .env, if present, to setup the environment
 config()


### PR DESCRIPTION
Resolves #110 

Sets the `version` variable from a static string instead of trying to read it from package.json. This is a hotfix until, or if, we figure out an approach for reading the version string from package.json in the snapshot filesystem of the binaries.