### PR TITLE
fix: send scopes with client secret authentication

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -92,11 +92,11 @@ async function getToken () {
 async function authenticateClientSecret () {
   const parameters = {
     form: {
-      grant_type: 'client_credentials'
+      grant_type: 'client_credentials',
+      scope: self.scope,
     },
     username: options.clientId,
     password: options.clientSecret,
-    scope: self.scope,
     responseType: 'json'
   }
 


### PR DESCRIPTION
This PR fixes the method that performs client secret authentication so the token request includes the `scope` parameter.