### PR TITLE
fix: read from package.json and include it in binary snapshot fs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ watched/
 .env
 *.log
 log.json
-bundle.js
+bundle.cjs
 coverage/

--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,7 @@ npm install -g pkg
 
 # Bundle
 printf "[BUILD_TASK] Bundling\n"
-npx esbuild index.js --bundle --platform=node --outfile=bundle.js
+npx esbuild index.js --bundle --platform=node --outfile=bundle.cjs
 check_exit_status "Bundling" 1
 
 # version=$(git describe --tags | sed 's/\(.*\)-.*/\1/')

--- a/lib/args.js
+++ b/lib/args.js
@@ -3,10 +3,9 @@ import help_default from './help.js'
 help_default()
 import { Command, Option, InvalidOptionArgumentError } from 'commander'
 import { readFileSync } from 'node:fs'
-import * as path from 'node:path'
 import * as logger from './logger.js'
 import { config } from 'dotenv' 
-import { resolve, sep, posix } from 'path'
+import { dirname, resolve, sep, posix } from 'node:path'
 import promptSync from 'prompt-sync'
 import { createPrivateKey } from 'crypto'
 
@@ -15,7 +14,7 @@ const component = 'args'
 
 function getVersion() {
   try {
-    const packageJsonText = readFileSync(`${path.dirname(process?.pkg?.defaultEntrypoint ?? '.')}/package.json`, 'utf8')
+    const packageJsonText = readFileSync(`${dirname(process?.pkg?.defaultEntrypoint ?? '.')}/package.json`, 'utf8')
     return JSON.parse(packageJsonText).version
   } 
   catch (error) {

--- a/lib/args.js
+++ b/lib/args.js
@@ -1,9 +1,9 @@
-const version = '1.4.2'
 
 import help_default from './help.js'
 help_default()
 import { Command, Option, InvalidOptionArgumentError } from 'commander'
-import { readFileSync } from 'fs'
+import { readFileSync } from 'node:fs'
+import * as path from 'node:path'
 import * as logger from './logger.js'
 import { config } from 'dotenv' 
 import { resolve, sep, posix } from 'path'
@@ -13,8 +13,20 @@ import { createPrivateKey } from 'crypto'
 const prompt = promptSync({ sigint:true })
 const component = 'args'
 
+function getVersion() {
+  try {
+    const packageJsonText = readFileSync(`${path.dirname(process?.pkg?.defaultEntrypoint ?? '.')}/package.json`, 'utf8')
+    return JSON.parse(packageJsonText).version
+  } 
+  catch (error) {
+    console.error('Error reading package.json:', error.message)
+    return '0.0.0'
+  }
+}
+
 let configValid = true
 
+const version = getVersion()
 
 // Use .env, if present, to setup the environment
 config()

--- a/pkg.config.json
+++ b/pkg.config.json
@@ -1,9 +1,9 @@
 {
     "name": "stigman-watcher",
-    "bin": "./bundle.js",
+    "bin": "./bundle.cjs",
     "pkg": {
         "targets": [ "node18-win", "node18-linuxstatic" ],
-        "assets": ["./node_modules/better-queue-memory/**"],
+        "assets": ["./node_modules/better-queue-memory/**", "./package.json"],
         "outputPath": "./bin"
     }
 }


### PR DESCRIPTION
- Revert the static assignment to the `version` variable introduced by #111 and once again call `getVersion()` to read it from `package.json`.
- Update `getVersion()` to return a value from the catch handler so errors here do not crash the entire process. Returning `undefined` from `getVersion()`  was the ultimate cause of #110.
- Construct the path to `package.json` using `process.pkg.defaultEntrypoint` if it exists, in order to support the binary build system.

The build system was updated to:
- include `package.json` in the binary snapshot file system
- change the extension of the CommonJS bundled code to `.cjs` so it is processed as CommonJS when in the snapshot filesystem. Our `package.json` includes `{"type": "module"}`, so using the previous name `bundle.js` caused node to attempt to process that file as ESM and fail.