### PR TITLE
Always schedule next scan, but skip it if queues are not empty. 

### DIFF
--- a/lib/scan.js
+++ b/lib/scan.js
@@ -1,6 +1,7 @@
 import { logger } from './logger.js'
 import { options } from './args.js'
 import { queue as parseQueue} from './parse.js'
+import { cargoQueue } from './cargo.js'
 import { serializeError } from 'serialize-error'
 import fg from 'fast-glob'
 import lineByLine from 'n-readlines'
@@ -11,6 +12,7 @@ const component = 'scan'
 const historySet = new Set() // in memory history set
 let isWriteScheduled = false // flag to indicate if there is pending files to write to the history file
 let timeoutId // id of the active setTimeout
+
 
 /**
  * Utility function that calls initHistory() and startScanner()
@@ -28,43 +30,52 @@ function initScanner() {
  */
 async function startScanner() { 
   const discoveredFiles = new Set() // in memory set of files discovered in the current scan
-  try {
-    // scan the path for files
-      const stream = fg.stream([`${options.path}/**/*.ckl`, `${options.path}/**/*.xml`, `${options.path}/**/*.cklb`], {
-          dot: !options.ignoreDot,
-          suppressErrors: true,
-          ignore: options.ignoreGlob ?? []
-      })
-      logger.info({ component, message: `scan started`, path: options.path })
-      // for each file discovered
-      for await (const entry of stream) {
-        discoveredFiles.add(entry)
-        logger.verbose({ component, message: `discovered file`, file: entry })
-        // check if the file is in the history
-        if (historySet.has(entry)) {
-          logger.verbose({component, message: `history match`, file: entry})
+
+    try {
+      //if the parseQueue and cargoQueue are empty, start a scan
+      if (parseQueue.length == 0 && cargoQueue.length == 0) {
+        logger.info({ component, message: `queue empty, starting scan` })
+      // scan the path for files
+        const stream = fg.stream([`${options.path}/**/*.ckl`, `${options.path}/**/*.xml`, `${options.path}/**/*.cklb`], {
+            dot: !options.ignoreDot,
+            suppressErrors: true,
+            ignore: options.ignoreGlob ?? []
+        })
+        logger.info({ component, message: `scan started`, path: options.path })
+        // for each file discovered
+        for await (const entry of stream) {
+          discoveredFiles.add(entry)
+          logger.verbose({ component, message: `discovered file`, file: entry })
+          // check if the file is in the history
+          if (historySet.has(entry)) {
+            logger.verbose({component, message: `history match`, file: entry})
+          }
+          // if the file is not in the history, add it to the in memory history set.
+          else {
+            parseQueue.push(entry)
+            logger.info({component, message: `queued for parsing`, file: entry})
+          }
         }
-        // if the file is not in the history, add it to the in memory history set.
-        else {
-          parseQueue.push(entry)
-          logger.info({component, message: `queued for parsing`, file: entry})
-        }
+        //Remove stale files: those in historySet but not found in the current scan
+        removeStaleFiles(discoveredFiles)
+        logger.info({ component, message: `scan ended`, path: options.path })
       }
-      //Remove stale files: those in historySet but not found in the current scan
-      removeStaleFiles(discoveredFiles)
-      logger.info({ component, message: `scan ended`, path: options.path })
-  } 
-  catch (e) {
-      logger.error({ component, error: serializeError(e) })
-  } 
-  finally {
-    if (!options.oneShot) {
-        scheduleNextScan()
+      else {
+        logger.info({ component, message: `scan skipped, queue not empty. parseQueue: ${parseQueue.length} cargoQueue: ${cargoQueue.length}` })
+      }
     } 
-    else {
-        logger.info({ component, message: `one-shot scan completed`, path: options.path })
+    catch (e) {
+        logger.error({ component, error: serializeError(e) })
     }
-  }
+    finally {
+      // if not a one-shot scan, always schedule the next scan
+      if (!options.oneShot) {
+          scheduleNextScan()
+      } 
+      else {
+          logger.info({ component, message: `one-shot scan completed`, path: options.path })
+      }
+    } 
 }
 
 /**

--- a/lib/scan.js
+++ b/lib/scan.js
@@ -32,37 +32,35 @@ async function startScanner() {
   const discoveredFiles = new Set() // in memory set of files discovered in the current scan
 
     try {
-      //if the parseQueue and cargoQueue are empty, start a scan
-      if (parseQueue.length == 0 && cargoQueue.length == 0) {
-        logger.info({ component, message: `queue empty, starting scan` })
+      //if the parseQueue and cargoQueue are not empty, skip the scan
+      if (parseQueue.length || cargoQueue.length) {
+        logger.info({ component, message: `scan skipped, queues not empty`, parseQueueSize: parseQueue.length, cargoQueueSize: cargoQueue.length })
+        return
+      }
       // scan the path for files
-        const stream = fg.stream([`${options.path}/**/*.ckl`, `${options.path}/**/*.xml`, `${options.path}/**/*.cklb`], {
-            dot: !options.ignoreDot,
-            suppressErrors: true,
-            ignore: options.ignoreGlob ?? []
-        })
-        logger.info({ component, message: `scan started`, path: options.path })
-        // for each file discovered
-        for await (const entry of stream) {
-          discoveredFiles.add(entry)
-          logger.verbose({ component, message: `discovered file`, file: entry })
-          // check if the file is in the history
-          if (historySet.has(entry)) {
-            logger.verbose({component, message: `history match`, file: entry})
-          }
-          // if the file is not in the history, add it to the in memory history set.
-          else {
-            parseQueue.push(entry)
-            logger.info({component, message: `queued for parsing`, file: entry})
-          }
+      const stream = fg.stream([`${options.path}/**/*.ckl`, `${options.path}/**/*.xml`, `${options.path}/**/*.cklb`], {
+          dot: !options.ignoreDot,
+          suppressErrors: true,
+          ignore: options.ignoreGlob ?? []
+      })
+      logger.info({ component, message: `scan started`, path: options.path })
+      // for each file discovered
+      for await (const entry of stream) {
+        discoveredFiles.add(entry)
+        logger.verbose({ component, message: `discovered file`, file: entry })
+        // check if the file is in the history
+        if (historySet.has(entry)) {
+          logger.verbose({component, message: `history match`, file: entry})
         }
-        //Remove stale files: those in historySet but not found in the current scan
-        removeStaleFiles(discoveredFiles)
-        logger.info({ component, message: `scan ended`, path: options.path })
+        // if the file is not in the history, add it to the in memory history set.
+        else {
+          parseQueue.push(entry)
+          logger.info({component, message: `queued for parsing`, file: entry})
+        }
       }
-      else {
-        logger.info({ component, message: `scan skipped, queue not empty. parseQueue: ${parseQueue.length} cargoQueue: ${cargoQueue.length}` })
-      }
+      //Remove stale files: those in historySet but not found in the current scan
+      removeStaleFiles(discoveredFiles)
+      logger.info({ component, message: `scan ended`, path: options.path })
     } 
     catch (e) {
         logger.error({ component, error: serializeError(e) })


### PR DESCRIPTION
always schedule scan. 
On scan start, check to see if both queues are empty. 
If empty, run scan, then schedule next one.  
If not empty, skip scan, schedule next one.