### PR TITLE
feat: schedule scan based on queue events

### DIFF
--- a/lib/scan.js
+++ b/lib/scan.js
@@ -1,6 +1,7 @@
 import { logger } from './logger.js'
 import { options } from './args.js'
 import { queue as parseQueue} from './parse.js'
+import { cargoQueue } from './cargo.js'
 import { serializeError } from 'serialize-error'
 import fg from 'fast-glob'
 import lineByLine from 'n-readlines'
@@ -11,11 +12,37 @@ const component = 'scan'
 const historySet = new Set() // in memory history set
 let isWriteScheduled = false // flag to indicate if there is pending files to write to the history file
 let timeoutId // id of the active setTimeout
+let isParseQueueActive = false
+let isCargoQueueActive = false
+
+function testScheduleNextScan() {
+  if (!isParseQueueActive && !isCargoQueueActive && !options.oneShot) {
+    scheduleNextScan()
+  }
+}
 
 /**
  * Utility function that calls initHistory() and startScanner()
  */
 function initScanner() {
+  parseQueue.on('task_queued', () => {
+    logger.info({ component, message: `parse_queue_task_queued` })
+    isParseQueueActive = true
+  })
+  parseQueue.on('drain', () => {
+    logger.info({ component, message: `parse_queue_drained` })
+    isParseQueueActive = false
+    testScheduleNextScan()
+  })
+  cargoQueue.on('task_queued', () => {
+    logger.info({ component, message: `cargo_queue_task_queued` })
+    isCargoQueueActive = true
+  })
+  cargoQueue.on('drain', () => {
+    logger.info({ component, message: `cargo_queue_drained` })
+    isCargoQueueActive = false
+    testScheduleNextScan()
+  })
   initHistory()
   startScanner()
   Alarm.on('alarmRaised', onAlarmRaised)
@@ -53,18 +80,11 @@ async function startScanner() {
       //Remove stale files: those in historySet but not found in the current scan
       removeStaleFiles(discoveredFiles)
       logger.info({ component, message: `scan ended`, path: options.path })
+      testScheduleNextScan()
   } 
   catch (e) {
       logger.error({ component, error: serializeError(e) })
   } 
-  finally {
-    if (!options.oneShot) {
-        scheduleNextScan()
-    } 
-    else {
-        logger.info({ component, message: `one-shot scan completed`, path: options.path })
-    }
-  }
 }
 
 /**

--- a/lib/scan.js
+++ b/lib/scan.js
@@ -80,7 +80,8 @@ async function startScanner() {
       //Remove stale files: those in historySet but not found in the current scan
       removeStaleFiles(discoveredFiles)
       logger.info({ component, message: `scan ended`, path: options.path })
-      testScheduleNextScan()
+      // allow queue event handlers to fire before calling testScheduleNextScan()
+      setTimeout(testScheduleNextScan, 0)
   } 
   catch (e) {
       logger.error({ component, error: serializeError(e) })
@@ -114,19 +115,6 @@ function scheduleNextScan() {
     message: `scan scheduled`, 
     path: options.path,
     delay: options.scanInterval 
-  })
-}
-
-/**
- * Cancels the next scan and logs.
- * References options properties {path}.
- */
-function cancelNextScan() {
-  clearTimeout(timeoutId)
-  logger.info({ 
-    component, 
-    message: `scan cancelled`, 
-    path: options.path
   })
 }
 

--- a/lib/scan.js
+++ b/lib/scan.js
@@ -350,7 +350,8 @@ function onAlarmRaised(alarmType) {
     message: `handling raised alarm`,
     alarmType
   })
-  cancelNextScan()
+  parseQueue.pause()
+  cargoQueue.pause()
 }
 
 /**
@@ -364,7 +365,8 @@ function onAlarmLowered(alarmType) {
     message: `handling lowered alarm`,
     alarmType
   })
-  startScanner()
+  parseQueue.resume()
+  cargoQueue.resume()
 }
 
 

--- a/lib/scan.js
+++ b/lib/scan.js
@@ -11,38 +11,50 @@ import Alarm from './alarm.js'
 const component = 'scan'
 const historySet = new Set() // in memory history set
 let isWriteScheduled = false // flag to indicate if there is pending files to write to the history file
-let timeoutId // id of the active setTimeout
-let isParseQueueActive = false
-let isCargoQueueActive = false
+let isParseQueueActive = false // flag to indicate if parseQueue has pending work
+let isCargoQueueActive = false // flag to indicate if cargoQueue has pending work
 
-function testScheduleNextScan() {
+/**
+ * Schedules the next scan if we're not in oneShot operation and the queues are idle 
+ */
+function tryScheduleNextScan() {
   if (!isParseQueueActive && !isCargoQueueActive && !options.oneShot) {
     scheduleNextScan()
   }
 }
 
 /**
- * Utility function that calls initHistory() and startScanner()
+ * - Attaches handlers for task_queued and drain events on the queues
+ * - Sets the flags that track if the queues have pending work
+ * - on drain events, try to schedule the next scan
  */
-function initScanner() {
+function initQueueEvents() {
   parseQueue.on('task_queued', () => {
-    logger.info({ component, message: `parse_queue_task_queued` })
+    logger.verbose({ component, message: `handling parseQueue event`, event: 'task_queued' })
     isParseQueueActive = true
   })
   parseQueue.on('drain', () => {
-    logger.info({ component, message: `parse_queue_drained` })
+    logger.verbose({ component, message: `handling parseQueue event`, event: 'drained' })
     isParseQueueActive = false
-    testScheduleNextScan()
+    tryScheduleNextScan()
   })
   cargoQueue.on('task_queued', () => {
-    logger.info({ component, message: `cargo_queue_task_queued` })
+    logger.verbose({ component, message: `handling cargoQueue event`, event: 'task_queued' })
     isCargoQueueActive = true
   })
   cargoQueue.on('drain', () => {
-    logger.info({ component, message: `cargo_queue_drained` })
+    logger.verbose({ component, message: `handling cargoQueue event`, event: 'drained' })
     isCargoQueueActive = false
-    testScheduleNextScan()
+    tryScheduleNextScan()
   })
+}
+
+/**
+ * Utility function that calls initQueueEvents(), initHistory() and startScanner()
+ * Attaches handlers for alarmRaised and alarmLowered
+ */
+function initScanner() {
+  initQueueEvents()
   initHistory()
   startScanner()
   Alarm.on('alarmRaised', onAlarmRaised)
@@ -80,8 +92,8 @@ async function startScanner() {
       //Remove stale files: those in historySet but not found in the current scan
       removeStaleFiles(discoveredFiles)
       logger.info({ component, message: `scan ended`, path: options.path })
-      // allow queue event handlers to fire before calling testScheduleNextScan()
-      setTimeout(testScheduleNextScan, 0)
+      // allow queue event handlers to execute before calling tryScheduleNextScan()
+      setTimeout(tryScheduleNextScan, 0)
   } 
   catch (e) {
       logger.error({ component, error: serializeError(e) })
@@ -104,7 +116,7 @@ function removeStaleFiles(currentFilesSet){
  * References options properties {path, scanInterval}.
  */
 function scheduleNextScan() {
-  timeoutId = setTimeout(() => {
+  setTimeout(() => {
     startScanner().catch(e => {
       logger.error({ component, error: serializeError(e) })
     })


### PR DESCRIPTION
Resolves #117 

Alternative approach to #127 that:
- schedules the next scan with a delay relative to the last worker of the current processing pipeline.
- avoids non-productive invocations of `startScanner()` by only scheduling when workers are finished 

