### PR TITLE
refactor: alarm handling

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -5,6 +5,7 @@ import { logger, getSymbol } from './logger.js'
 import Alarm from './alarm.js'
 import * as CONSTANTS from './consts.js'
 
+const component = 'api'
 const cache = {
   collection: null,
   assets: null,
@@ -33,6 +34,17 @@ async function apiRequest({method = 'GET', endpoint, json, authorize = true, ful
     method,
     url: `${options.api}${endpoint}`,
     responseType: 'json',
+    retry: {
+      errorCodes: [
+        'ECONNRESET',
+        'EADDRINUSE',
+        'ECONNREFUSED',
+        'EPIPE',
+        'ENOTFOUND',
+        'ENETUNREACH',
+        'EAI_AGAIN'
+      ]
+    },
     timeout: {
       response: options.responseTimeout
     }  
@@ -71,7 +83,7 @@ async function apiRequest({method = 'GET', endpoint, json, authorize = true, ful
     if (e.response?.statusCode === 403) {
       Alarm.noGrant(true)
     }
-    else if (e.code === 'ETIMEDOUT' || e.response?.statusCode === 503) {
+    else if (e.code !== 'ERR_NON_2XX_3XX_RESPONSE') {
       Alarm.apiOffline(true)
     }
     throw (e)
@@ -81,6 +93,17 @@ async function apiRequest({method = 'GET', endpoint, json, authorize = true, ful
 async function apiGetRequestsParallel({endpoints, authorize = true}) {
   const requestOptions = {
     responseType: 'json',
+    retry: {
+      errorCodes: [
+        'ECONNRESET',
+        'EADDRINUSE',
+        'ECONNREFUSED',
+        'EPIPE',
+        'ENOTFOUND',
+        'ENETUNREACH',
+        'EAI_AGAIN'
+      ]
+    },
     timeout: {
       response: options.responseTimeout
     }  
@@ -142,9 +165,23 @@ export async function getCollectionAssets({collectionId, targets}) {
       }
       return `${options.api}/assets?collectionId=${collectionId}&${metadataParams.join('&')}&projection=stigs`
     })
-    const responses = await apiGetRequestsParallel({
-      endpoints: new Set([...namedEndpoints, ...metadataEndpoints])
-    })
+    let responses
+    try {
+      responses = await apiGetRequestsParallel({
+        endpoints: new Set([...namedEndpoints, ...metadataEndpoints])
+      })
+    }
+    catch (e) {
+      logError(e)
+      if (e.response?.statusCode === 403) {
+        Alarm.noGrant(true)
+      }
+      else if (e.code !== 'ERR_NON_2XX_3XX_RESPONSE') {
+        Alarm.apiOffline(true)
+      }
+      throw (e)
+    }
+  
     const assets = []
     for (const response of responses) {
       logResponse (response)
@@ -205,7 +242,7 @@ export function canUserAccept() {
 
 function logResponse (response) {
   logger.http({
-    component: 'api',
+    component,
     message: 'query',
     request: {
       method: response.request.options?.method,
@@ -216,7 +253,7 @@ function logResponse (response) {
     }
   })
   logger.debug({
-    component: 'api',
+    component,
     message: 'query bodies',
     request: {
       method: response.request.options?.method,
@@ -231,18 +268,22 @@ function logResponse (response) {
 }
 
 function logError (e) {
-  logger.error({
-    component: 'api',
+  const logObject = {
+    component,
+    code: e.code,
     message: e.message,
     request: {
       method: e.request?.options?.method,
       url: e.request?.requestUrl
-    } ,
-    response: {
+    } 
+  }
+  if (e.code === 'ERR_NON_2XX_3XX_RESPONSE') {
+    logObject.response = {
       status: e.response?.statusCode,
       body: e.response?.body
     }
-  })
+  }
+  logger.error(logObject)
 }
 
 /**
@@ -269,7 +310,7 @@ let alarmRetryCount = 0
  */
 function offlineRetryHandler() {
   logger.info({
-    component: 'api',
+    component,
     message: 'Testing if API is online'
   })
   alarmRetryCount++
@@ -281,7 +322,7 @@ function offlineRetryHandler() {
   .catch(() => {
     if (alarmRetryCount >= alarmRetryLimit) {
       logger.info({
-        component: 'api',
+        component,
         message: 'API connectivity maximum tries reached, requesting shutdown'
       })
       Alarm.shutdown(CONSTANTS.ERR_APIOFFLINE)

--- a/lib/args.js
+++ b/lib/args.js
@@ -135,7 +135,7 @@ if (options.logFile) {
 
 logger.logger.log({
   level: 'debug',
-  component: component,
+  component,
   message: 'parsed options',
   options: options
 })
@@ -150,7 +150,7 @@ for (const key in CONSTANTS.configBounds) {
   if (options[key] < bounds.min || options[key] > bounds.max) {
     logger.logger.log({
       level: 'error',
-      component: component,
+      component,
       message: `config value out of bounds: ${key} = ${options[key]}, must be between ${bounds.min} and ${bounds.max}`
     })
     configValid = false
@@ -189,7 +189,7 @@ if (configValid) {
       // Could not make a private key
       logger.logger.log({
         level: 'error',
-        component: component,
+        component,
         message: 'private key error',
         file: options.clientKey,
         error: e
@@ -206,7 +206,7 @@ if (configValid) {
     if (!options.clientSecret) {
       // Don't know the client secret
       logger.logger.error({
-        component: component,
+        component,
         message: 'Missing client secret'
       })
       configValid = false

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -5,12 +5,13 @@ import * as api from './api.js'
 import { serializeError } from 'serialize-error'
 import { TaskObject } from '@nuwcdivnpt/stig-manager-client-modules'
 import { addToHistory } from './scan.js'
+import Alarm from './alarm.js'
+
 
 const component = 'cargo'
 let batchId = 0
 
 async function writer ( taskAsset ) {
-  const component = 'writer'
   try {
     logger.debug({ 
       component,
@@ -22,7 +23,7 @@ async function writer ( taskAsset ) {
       const r = await api.createOrGetAsset( taskAsset.assetProps )
       // GET projection=stigs is an object, we just need the benchmarkIds
       r.apiAsset.stigs = r.apiAsset.stigs.map ( stig => stig.benchmarkId )
-      logger.info({ component: component, message: `asset ${r.created ? 'created' : 'found'}`, asset: r.apiAsset })
+      logger.info({ component, message: `asset ${r.created ? 'created' : 'found'}`, asset: r.apiAsset })
       // Iterate: If created === false, then STIG assignments should be vetted again
       taskAsset.assetProps = r.apiAsset
     }
@@ -35,7 +36,7 @@ async function writer ( taskAsset ) {
         stigs: taskAsset.assetProps.stigs
       })
       r.stigs = r.stigs.map( stig => stig.benchmarkId )
-      logger.info({ component: component, message: `STIG assignments updated`, 
+      logger.info({ component, message: `STIG assignments updated`, 
         asset: { assetId: r.assetId, name: r.name, stigs: r.stigs } })
     }
 
@@ -69,7 +70,7 @@ async function writer ( taskAsset ) {
   }  
   catch (error) {
     const errorObj = {
-      component: error.component ?? component,
+      component,
       message: error?.message,
     }
     if (error.request) {
@@ -110,8 +111,10 @@ async function resultsHandler( parsedResults, cb ) {
     const tasks = new TaskObject ({ parsedResults, apiAssets, apiStigs, options })
     isModeScan && tasks.errors.length && addToHistory(tasks.errors.map(e => e.sourceRef))
     for ( const taskAsset of tasks.taskAssets.values() ) {
-      const success = await writer( taskAsset )
-      isModeScan && success && addToHistory(taskAsset.sourceRefs)
+      if (!Alarm.isAlarmed()) {
+        const success = await writer( taskAsset )
+        isModeScan && success && addToHistory(taskAsset.sourceRefs)
+      }
     }
     logger.info({component, message: 'batch ended', batchId})
     cb()
@@ -130,7 +133,7 @@ const cargoQueue = new Queue(resultsHandler, {
 cargoQueue
 .on('batch_failed', (err) => {
   logger.error( {
-    component: 'cargo',
+    component,
     message: err?.message,
   })
 })
@@ -139,9 +142,45 @@ cargoQueue
 })
 .on('drain', () => {
   if (options.oneShot) {
-    logger.info({component: 'cargo', message: 'finished one shot mode'})
+    logger.info({component, message: 'finished one shot mode'})
     process.exit()
   }
 })
+
+Alarm.on('alarmRaised', onAlarmRaised)
+Alarm.on('alarmLowered', onAlarmLowered)
+
+/**
+ * @typedef {import('./alarm.js').AlarmType} AlarmType
+ */
+
+/**
+ * Handles raised alarms
+ * @param {AlarmType} alarmType - The type of alarm.
+ * Intended to be a callback function of Alarm.on('alarmRaised')
+ */
+function onAlarmRaised (alarmType) {
+  logger.info({
+    component,
+    message: `pausing queue on alarm raised`,
+    alarmType
+  })
+  cargoQueue.pause()
+}
+
+/**
+ * Handles lowered alarms
+ * @param {AlarmType} alarmType - The type of alarm.
+ * Intended to be a callback function of Alarm.on('alarmRaised')
+ */
+function onAlarmLowered (alarmType) {
+  logger.info({
+    component,
+    message: `resuming queue on alarm lowered`,
+    alarmType
+  })
+  cargoQueue.resume()
+}
+
 
 export { cargoQueue }

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,9 +1,8 @@
 import {options} from './args.js'
 import { logger } from './logger.js'
-import { queue } from './parse.js'
+import { parseQueue } from './parse.js'
 import { serializeError } from 'serialize-error'
 import { watch } from 'chokidar'
-import Alarm from './alarm.js'
 
 const component = 'events'
 
@@ -28,8 +27,6 @@ function startFsEventWatcher () {
   })
   watcher.on('error', onError )
   watcher.on('add', onAdd )
-  Alarm.on('alarmRaised', onAlarmRaised)
-  Alarm.on('alarmLowered', onAlarmLowered)
 }
 
 function onAdd (file) {
@@ -42,7 +39,7 @@ function onAdd (file) {
       event:  'add',
       file
     })
-    queue.push( file )
+    parseQueue.push( file )
   }
 }
 
@@ -51,24 +48,6 @@ function onError (e) {
     component,
     error: serializeError(e)
   })
-}
-
-function onAlarmRaised (alarmType) {
-  logger.info({
-    component,
-    message: `pausing parse queue on alarm raised`,
-    alarmType
-  })
-  queue.pause()
-}
-
-function onAlarmLowered (alarmType) {
-  logger.info({
-    component,
-    message: `resuming parse queue on alarm lowered`,
-    alarmType
-  })
-  queue.resume()
 }
 
 export default startFsEventWatcher

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -6,7 +6,9 @@ import { promises as fs } from 'fs'
 import { reviewsFromCkl, reviewsFromScc, reviewsFromCklb } from '@nuwcdivnpt/stig-manager-client-modules'
 import { addToHistory } from './scan.js'
 import { options } from './args.js'
+import Alarm from './alarm.js'
 
+const component = 'parser'
 const defaultImportOptions = {
   autoStatus: 'saved',
   unreviewed: 'commented',
@@ -34,7 +36,6 @@ function canUserAccept () {
 }
 
 async function parseFileAndEnqueue (file, cb) {
-  const component = 'parser'
   try {
     const extension = file.substring(file.lastIndexOf(".") + 1)
     let parseFn
@@ -52,7 +53,7 @@ async function parseFileAndEnqueue (file, cb) {
     }
     // ReviewParser params
     const data = await fs.readFile(file)
-    logger.verbose({component: component, message: `readFile succeeded`, file: file})
+    logger.verbose({component, message: `readFile succeeded`, file: file})
 
     const apiCollection = cache.collection
     const importOptions = safeJSONParse(apiCollection.metadata?.importOptions) ?? defaultImportOptions
@@ -68,7 +69,7 @@ async function parseFileAndEnqueue (file, cb) {
       scapBenchmarkMap,
       sourceRef: file
     })
-    logger.debug({component: component, message: `parse results`, results: parseResult})
+    logger.debug({component, message: `parse results`, results: parseResult})
     
     cargoQueue.push( parseResult )
     
@@ -79,20 +80,56 @@ async function parseFileAndEnqueue (file, cb) {
         stats: checklist.stats
       })
     }
-    logger.verbose({component: component, message: `results queued`, file: parseResult.sourceRef, 
+    logger.verbose({component, message: `results queued`, file: parseResult.sourceRef, 
       target: parseResult.target.name, checklists: checklistInfo })
     cb(null, parseResult)
   }
   catch (e) {
-    logger.warn({component: component, message: e.message, file: file})
+    logger.warn({component, message: e.message, file})
     options.mode === 'scan' && addToHistory(file)
     cb(e, null)
   }
 }
 
-export const queue = new Queue (parseFileAndEnqueue, {
+export const parseQueue = new Queue (parseFileAndEnqueue, {
   concurrent: 8
 })
+
+Alarm.on('alarmRaised', onAlarmRaised)
+Alarm.on('alarmLowered', onAlarmLowered)
+
+/**
+ * @typedef {import('./alarm.js').AlarmType} AlarmType
+ */
+
+/**
+ * Handles raised alarms
+ * @param {AlarmType} alarmType - The type of alarm.
+ * Intended to be a callback function of Alarm.on('alarmRaised')
+ */
+function onAlarmRaised (alarmType) {
+  logger.info({
+    component,
+    message: `pausing queue on alarm raised`,
+    alarmType
+  })
+  parseQueue.pause()
+}
+
+/**
+ * Handles lowered alarms
+ * @param {AlarmType} alarmType - The type of alarm.
+ * Intended to be a callback function of Alarm.on('alarmRaised')
+ */
+function onAlarmLowered (alarmType) {
+  logger.info({
+    component,
+    message: `resuming queue on alarm lowered`,
+    alarmType
+  })
+  parseQueue.resume()
+}
+
 
 
 

--- a/lib/scan.js
+++ b/lib/scan.js
@@ -1,6 +1,6 @@
 import { logger } from './logger.js'
 import { options } from './args.js'
-import { queue as parseQueue} from './parse.js'
+import { parseQueue} from './parse.js'
 import { cargoQueue } from './cargo.js'
 import { serializeError } from 'serialize-error'
 import fg from 'fast-glob'
@@ -51,14 +51,11 @@ function initQueueEvents() {
 
 /**
  * Utility function that calls initQueueEvents(), initHistory() and startScanner()
- * Attaches handlers for alarmRaised and alarmLowered
  */
 function initScanner() {
   initQueueEvents()
   initHistory()
   startScanner()
-  Alarm.on('alarmRaised', onAlarmRaised)
-  Alarm.on('alarmLowered', onAlarmLowered)
 }
 
 /**
@@ -78,7 +75,6 @@ async function startScanner() {
       // for each file discovered
       for await (const entry of stream) {
         discoveredFiles.add(entry)
-        logger.verbose({ component, message: `discovered file`, file: entry })
         // check if the file is in the history
         if (historySet.has(entry)) {
           logger.verbose({component, message: `history match`, file: entry})
@@ -279,7 +275,7 @@ function writeHistoryToFile() {
       const data = Array.from(historySet).join('\n') + '\n'
       fs.writeFileSync(options.historyFile, data) 
       logger.verbose({
-        component:component,
+        component,
         message: `history file overwritten with history data from memory`,
         file: options.historyFile
       })
@@ -334,41 +330,6 @@ function isHistoryFileWriteable() {
     return false
   }
 }
-
-/**
- * @typedef {import('./alarm.js').AlarmType} AlarmType
- */
-
-/**
- * Handles raised alarms
- * @param {AlarmType} alarmType - The type of alarm.
- * Intended to be a callback function of Alarm.on('alarmRaised')
- */
-function onAlarmRaised(alarmType) {
-  logger.verbose({
-    component,
-    message: `handling raised alarm`,
-    alarmType
-  })
-  parseQueue.pause()
-  cargoQueue.pause()
-}
-
-/**
- * Handles lowered alarms
- * @param {AlarmType} alarmType - The type of alarm.
- * Intended to be a callback function of Alarm.on('alarmRaised')
- */
-function onAlarmLowered(alarmType) {
-  logger.verbose({
-    component,
-    message: `handling lowered alarm`,
-    alarmType
-  })
-  parseQueue.resume()
-  cargoQueue.resume()
-}
-
 
 export { 
   startScanner,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "stigman-watcher",
+  "name": "@nuwcdivnpt/stigman-watcher",
   "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "stigman-watcher",
+      "name": "@nuwcdivnpt/stigman-watcher",
       "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
-        "@nuwcdivnpt/stig-manager-client-modules": "^1.4.1",
+        "@nuwcdivnpt/stig-manager-client-modules": "^1.4.2",
         "atob": "^2.1.2",
         "better-queue": "^3.8.10",
         "chokidar": "^3.5.1",
@@ -497,9 +497,9 @@
       }
     },
     "node_modules/@nuwcdivnpt/stig-manager-client-modules": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@nuwcdivnpt/stig-manager-client-modules/-/stig-manager-client-modules-1.4.1.tgz",
-      "integrity": "sha512-Zd0l9v4JdjnmCtMGPlj7d3vuA7iwXWW6Cw91pKopC6RG6Pf0uL5HhF2FOKNJUgqa4drrlAl5/lFI8aRYK30cag==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@nuwcdivnpt/stig-manager-client-modules/-/stig-manager-client-modules-1.4.2.tgz",
+      "integrity": "sha512-WsEpaHR1zMzPRqlRVDlyoE9UZrV3e6anMOn8uzDAC/Q0DbJS9k0EtUCKUo0FcHZu239un3dAUwoip2ypN2chlg==",
       "hasInstallScript": true
     },
     "node_modules/@sindresorhus/is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,9 +63,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.1.tgz",
-      "integrity": "sha512-m55cpeupQ2DbuRGQMMZDzbv9J9PgVelPjlcmM5kxHnrBdBx6REaEd7LamYV7Dm8N7rCyR/XwU6rVP8ploKtIkA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
       "cpu": [
         "ppc64"
       ],
@@ -79,9 +79,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.1.tgz",
-      "integrity": "sha512-4j0+G27/2ZXGWR5okcJi7pQYhmkVgb4D7UKwxcqrjhvp5TKWx3cUjgB1CGj1mfdmJBQ9VnUGgUhign+FPF2Zgw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
       "cpu": [
         "arm"
       ],
@@ -95,9 +95,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.1.tgz",
-      "integrity": "sha512-hCnXNF0HM6AjowP+Zou0ZJMWWa1VkD77BXe959zERgGJBBxB+sV+J9f/rcjeg2c5bsukD/n17RKWXGFCO5dD5A==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
       "cpu": [
         "arm64"
       ],
@@ -111,9 +111,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.1.tgz",
-      "integrity": "sha512-MSfZMBoAsnhpS+2yMFYIQUPs8Z19ajwfuaSZx+tSl09xrHZCjbeXXMsUF/0oq7ojxYEpsSo4c0SfjxOYXRbpaA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
       "cpu": [
         "x64"
       ],
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.1.tgz",
-      "integrity": "sha512-Ylk6rzgMD8klUklGPzS414UQLa5NPXZD5tf8JmQU8GQrj6BrFA/Ic9tb2zRe1kOZyCbGl+e8VMbDRazCEBqPvA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
       "cpu": [
         "arm64"
       ],
@@ -143,9 +143,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.1.tgz",
-      "integrity": "sha512-pFIfj7U2w5sMp52wTY1XVOdoxw+GDwy9FsK3OFz4BpMAjvZVs0dT1VXs8aQm22nhwoIWUmIRaE+4xow8xfIDZA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
       "cpu": [
         "x64"
       ],
@@ -159,9 +159,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.1.tgz",
-      "integrity": "sha512-UyW1WZvHDuM4xDz0jWun4qtQFauNdXjXOtIy7SYdf7pbxSWWVlqhnR/T2TpX6LX5NI62spt0a3ldIIEkPM6RHw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
       "cpu": [
         "arm64"
       ],
@@ -175,9 +175,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.1.tgz",
-      "integrity": "sha512-itPwCw5C+Jh/c624vcDd9kRCCZVpzpQn8dtwoYIt2TJF3S9xJLiRohnnNrKwREvcZYx0n8sCSbvGH349XkcQeg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
       "cpu": [
         "x64"
       ],
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.1.tgz",
-      "integrity": "sha512-LojC28v3+IhIbfQ+Vu4Ut5n3wKcgTu6POKIHN9Wpt0HnfgUGlBuyDDQR4jWZUZFyYLiz4RBBBmfU6sNfn6RhLw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
       "cpu": [
         "arm"
       ],
@@ -207,9 +207,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.1.tgz",
-      "integrity": "sha512-cX8WdlF6Cnvw/DO9/X7XLH2J6CkBnz7Twjpk56cshk9sjYVcuh4sXQBy5bmTwzBjNVZze2yaV1vtcJS04LbN8w==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
       "cpu": [
         "arm64"
       ],
@@ -223,9 +223,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.1.tgz",
-      "integrity": "sha512-4H/sQCy1mnnGkUt/xszaLlYJVTz3W9ep52xEefGtd6yXDQbz/5fZE5dFLUgsPdbUOQANcVUa5iO6g3nyy5BJiw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
       "cpu": [
         "ia32"
       ],
@@ -239,9 +239,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.1.tgz",
-      "integrity": "sha512-c0jgtB+sRHCciVXlyjDcWb2FUuzlGVRwGXgI+3WqKOIuoo8AmZAddzeOHeYLtD+dmtHw3B4Xo9wAUdjlfW5yYA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
       "cpu": [
         "loong64"
       ],
@@ -255,9 +255,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.1.tgz",
-      "integrity": "sha512-TgFyCfIxSujyuqdZKDZ3yTwWiGv+KnlOeXXitCQ+trDODJ+ZtGOzLkSWngynP0HZnTsDyBbPy7GWVXWaEl6lhA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
       "cpu": [
         "mips64el"
       ],
@@ -271,9 +271,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.1.tgz",
-      "integrity": "sha512-b+yuD1IUeL+Y93PmFZDZFIElwbmFfIKLKlYI8M6tRyzE6u7oEP7onGk0vZRh8wfVGC2dZoy0EqX1V8qok4qHaw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
       "cpu": [
         "ppc64"
       ],
@@ -287,9 +287,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.1.tgz",
-      "integrity": "sha512-wpDlpE0oRKZwX+GfomcALcouqjjV8MIX8DyTrxfyCfXxoKQSDm45CZr9fanJ4F6ckD4yDEPT98SrjvLwIqUCgg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
       "cpu": [
         "riscv64"
       ],
@@ -303,9 +303,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.1.tgz",
-      "integrity": "sha512-5BepC2Au80EohQ2dBpyTquqGCES7++p7G+7lXe1bAIvMdXm4YYcEfZtQrP4gaoZ96Wv1Ute61CEHFU7h4FMueQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
       "cpu": [
         "s390x"
       ],
@@ -319,9 +319,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.1.tgz",
-      "integrity": "sha512-5gRPk7pKuaIB+tmH+yKd2aQTRpqlf1E4f/mC+tawIm/CGJemZcHZpp2ic8oD83nKgUPMEd0fNanrnFljiruuyA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
       "cpu": [
         "x64"
       ],
@@ -335,9 +335,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.1.tgz",
-      "integrity": "sha512-4fL68JdrLV2nVW2AaWZBv3XEm3Ae3NZn/7qy2KGAt3dexAgSVT+Hc97JKSZnqezgMlv9x6KV0ZkZY7UO5cNLCg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
       "cpu": [
         "x64"
       ],
@@ -351,9 +351,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.1.tgz",
-      "integrity": "sha512-GhRuXlvRE+twf2ES+8REbeCb/zeikNqwD3+6S5y5/x+DYbAQUNl0HNBs4RQJqrechS4v4MruEr8ZtAin/hK5iw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
       "cpu": [
         "x64"
       ],
@@ -367,9 +367,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.1.tgz",
-      "integrity": "sha512-ZnWEyCM0G1Ex6JtsygvC3KUUrlDXqOihw8RicRuQAzw+c4f1D66YlPNNV3rkjVW90zXVsHwZYWbJh3v+oQFM9Q==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
       "cpu": [
         "x64"
       ],
@@ -383,9 +383,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.1.tgz",
-      "integrity": "sha512-QZ6gXue0vVQY2Oon9WyLFCdSuYbXSoxaZrPuJ4c20j6ICedfsDilNPYfHLlMH7vGfU5DQR0czHLmJvH4Nzis/A==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
       "cpu": [
         "arm64"
       ],
@@ -399,9 +399,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.1.tgz",
-      "integrity": "sha512-HzcJa1NcSWTAU0MJIxOho8JftNp9YALui3o+Ny7hCh0v5f90nprly1U3Sj1Ldj/CvKKdvvFsCRvDkpsEMp4DNw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
       "cpu": [
         "ia32"
       ],
@@ -415,9 +415,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.1.tgz",
-      "integrity": "sha512-0MBh53o6XtI6ctDnRMeQ+xoCN8kD2qI1rY1KgF/xdWQwoFeKou7puvDfV8/Wv4Ctx2rRpET/gGdz3YlNtNACSA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
       "cpu": [
         "x64"
       ],
@@ -455,9 +455,9 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.23",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.23.tgz",
-      "integrity": "sha512-9/4foRoUKp8s96tSkh8DlAAc5A0Ty8vLXld+l9gjKKY6ckwI8G15f0hskGmuLZu78ZlGa1vtsfOa+lnB4vG6Jg==",
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -555,9 +555,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.11.22",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.22.tgz",
-      "integrity": "sha512-/G+IxWxma6V3E+pqK1tSl2Fo1kl41pK1yeCyDsgkF9WlVAme4j5ISYM2zR11bgLFJGLN5sVK40T4RJNuiZbEjA==",
+      "version": "20.14.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
+      "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -574,12 +574,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
-    },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
     },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
@@ -679,11 +673,14 @@
       "integrity": "sha512-SWg5wFIShYffEmJpI6LgbL8/3Dqhku7xI1oEiy6FroP9DbcZlG0ZDjxvPdP9t7hTGW40IpIcC6zVoGT1oxjOuA=="
     },
     "node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/brace-expansion": {
@@ -696,11 +693,11 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -780,13 +777,13 @@
       }
     },
     "node_modules/chai": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.0.tgz",
-      "integrity": "sha512-kDZ7MZyM6Q1DhR9jy7dalKohXQ2yrlXkk59CR52aRKxJrobmlBNqnFQxX9xOX8w+4mz8SYlKJa/7D7ddltFXCw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.1.tgz",
+      "integrity": "sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^2.0.1",
-        "check-error": "^2.0.0",
+        "check-error": "^2.1.1",
         "deep-eql": "^5.0.1",
         "loupe": "^3.1.0",
         "pathval": "^2.0.0"
@@ -812,9 +809,9 @@
       }
     },
     "node_modules/check-error": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.0.0.tgz",
-      "integrity": "sha512-tjLAOBHKVxtPoHe/SA7kNOMvhCRdCJ3vETdeY0RuAc9popf+hyaSV6ZEg9hr4cpWF7jmo/JSWEnLDrnijS9Tog==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
       "dev": true,
       "engines": {
         "node": ">= 16"
@@ -1020,9 +1017,9 @@
       }
     },
     "node_modules/deep-eql": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.1.tgz",
-      "integrity": "sha512-nwQCf6ne2gez3o1MxWifqkciwt0zhl0LO1/UwVu4uMBuPmflWM4oQ70XMqHqnBJA+nhzncaqL9HVL6KkHJ28lw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -1081,9 +1078,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.1.tgz",
-      "integrity": "sha512-OJwEgrpWm/PCMsLVWXKqvcjme3bHNpOgN7Tb6cQnR5n0TPbQx1/Xrn7rqM+wn17bYeT6MGB5sn1Bh5YiGi70nA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1093,29 +1090,29 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.20.1",
-        "@esbuild/android-arm": "0.20.1",
-        "@esbuild/android-arm64": "0.20.1",
-        "@esbuild/android-x64": "0.20.1",
-        "@esbuild/darwin-arm64": "0.20.1",
-        "@esbuild/darwin-x64": "0.20.1",
-        "@esbuild/freebsd-arm64": "0.20.1",
-        "@esbuild/freebsd-x64": "0.20.1",
-        "@esbuild/linux-arm": "0.20.1",
-        "@esbuild/linux-arm64": "0.20.1",
-        "@esbuild/linux-ia32": "0.20.1",
-        "@esbuild/linux-loong64": "0.20.1",
-        "@esbuild/linux-mips64el": "0.20.1",
-        "@esbuild/linux-ppc64": "0.20.1",
-        "@esbuild/linux-riscv64": "0.20.1",
-        "@esbuild/linux-s390x": "0.20.1",
-        "@esbuild/linux-x64": "0.20.1",
-        "@esbuild/netbsd-x64": "0.20.1",
-        "@esbuild/openbsd-x64": "0.20.1",
-        "@esbuild/sunos-x64": "0.20.1",
-        "@esbuild/win32-arm64": "0.20.1",
-        "@esbuild/win32-ia32": "0.20.1",
-        "@esbuild/win32-x64": "0.20.1"
+        "@esbuild/aix-ppc64": "0.20.2",
+        "@esbuild/android-arm": "0.20.2",
+        "@esbuild/android-arm64": "0.20.2",
+        "@esbuild/android-x64": "0.20.2",
+        "@esbuild/darwin-arm64": "0.20.2",
+        "@esbuild/darwin-x64": "0.20.2",
+        "@esbuild/freebsd-arm64": "0.20.2",
+        "@esbuild/freebsd-x64": "0.20.2",
+        "@esbuild/linux-arm": "0.20.2",
+        "@esbuild/linux-arm64": "0.20.2",
+        "@esbuild/linux-ia32": "0.20.2",
+        "@esbuild/linux-loong64": "0.20.2",
+        "@esbuild/linux-mips64el": "0.20.2",
+        "@esbuild/linux-ppc64": "0.20.2",
+        "@esbuild/linux-riscv64": "0.20.2",
+        "@esbuild/linux-s390x": "0.20.2",
+        "@esbuild/linux-x64": "0.20.2",
+        "@esbuild/netbsd-x64": "0.20.2",
+        "@esbuild/openbsd-x64": "0.20.2",
+        "@esbuild/sunos-x64": "0.20.2",
+        "@esbuild/win32-arm64": "0.20.2",
+        "@esbuild/win32-ia32": "0.20.2",
+        "@esbuild/win32-x64": "0.20.2"
       }
     },
     "node_modules/escalade": {
@@ -1168,9 +1165,9 @@
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -1209,9 +1206,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.0.tgz",
+      "integrity": "sha512-CrWQNaEl1/6WeZoarcM9LHupTo3RpZO2Pdk1vktwzPiQTsJnAKJmm3TACKeG5UZbWDfaH2AbvYxzP96y0MT7fA==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
@@ -1279,6 +1276,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
       "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -1380,6 +1378,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -1670,9 +1669,9 @@
       }
     },
     "node_modules/loupe": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.0.tgz",
-      "integrity": "sha512-qKl+FrLXUhFuHUoDJG7f8P8gEMHq9NFS0c6ghXG1J0rldmZFQZoNVv/vyirE9qwCIhWZDsvEFd1sbFu3GvRQFg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.1.tgz",
+      "integrity": "sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==",
       "dev": true,
       "dependencies": {
         "get-func-name": "^2.0.1"
@@ -1684,17 +1683,6 @@
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/make-dir": {
@@ -1721,11 +1709,11 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -1753,9 +1741,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.3.0.tgz",
-      "integrity": "sha512-uF2XJs+7xSLsrmIvn37i/wnc91nw7XjOQB8ccyx5aEgdnohr7n+rEiZP23WkCYHjilR6+EboEnbq/ZQDz4LSbg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.4.0.tgz",
+      "integrity": "sha512-eqhGB8JKapEYcC4ytX/xrzKforgEc3j1pGlAXVy3eRwrtAy5/nIfT1SvgGzfN0XZZxeLq0aQWkOUAmqIJiv+bA==",
       "dev": true,
       "dependencies": {
         "ansi-colors": "4.1.1",
@@ -1886,9 +1874,9 @@
       "integrity": "sha512-mTCTZk29tmX1OGfVkPt63H3c3VqXrI2Kvua98S7iUIB/Gbp0MNw05YtUomxQIxnnKMyRIIuY9izPcFixzhSBrA=="
     },
     "node_modules/nodemon": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.0.tgz",
-      "integrity": "sha512-xqlktYlDMCepBJd43ZQhjWwMw2obW/JRvkrLxq5RCNcuDDX1DbcPT+qT1IlIIdf+DhnWs90JpTMe+Y5KxOchvA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.3.tgz",
+      "integrity": "sha512-m4Vqs+APdKzDFpuaL9F9EVOF85+h070FnkHVEoU4+rmT6Vw0bmNl7s61VEkY/cJkL7RCv1p4urnUDUMrS5rk2w==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.5.2",
@@ -1954,21 +1942,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
-      "dev": true,
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/normalize-path": {
@@ -2258,12 +2231,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2441,6 +2411,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -2486,13 +2457,10 @@
       }
     },
     "node_modules/touch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
       "dev": true,
-      "dependencies": {
-        "nopt": "~1.0.10"
-      },
       "bin": {
         "nodetouch": "bin/nodetouch.js"
       }
@@ -2574,9 +2542,9 @@
       }
     },
     "node_modules/winston": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
-      "integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.13.0.tgz",
+      "integrity": "sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==",
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",
@@ -2588,7 +2556,7 @@
         "safe-stable-stringify": "^2.3.1",
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
-        "winston-transport": "^4.5.0"
+        "winston-transport": "^4.7.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -2643,11 +2611,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@nuwcdivnpt/stig-manager-client-modules": "^1.4.1",
+    "@nuwcdivnpt/stig-manager-client-modules": "^1.4.2",
     "atob": "^2.1.2",
     "better-queue": "^3.8.10",
     "chokidar": "^3.5.1",


### PR DESCRIPTION
Resolves #121 
Resolves #119

- moves alarm handlers that pause the queues from `scan.js` and `event.js` into `parse.js` and `cargo.js`.
- refactors error handling in `api.js`
- updates many object literals to use shorthand property notation
- updates `@nuwcdivnpt/stig-manager-client-modules` to v1.4.2, which adds support for truncating Asset properties in accordance with the STIG Manager API definition
- updates all other dependencies to their most recent versions, in accordance with their semver rules in `package.json`

