### PR TITLE
chore: release 1.5.1. Updates to support stigman api changes in 1.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nuwcdivnpt/stigman-watcher",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nuwcdivnpt/stigman-watcher",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@nuwcdivnpt/stig-manager-client-modules": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuwcdivnpt/stigman-watcher",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "CLI that watches a path for STIG test result files on behalf of a STIG Manager Collection.",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
Changes accessLevel to RoleId to support changes in stigman api 1.5.3. Backwards compatible with older versions of the API.