### PR TITLE
Asset name issue 

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -170,7 +170,6 @@ export async function getCollectionAssets({ collectionId, targets }) {
     nameBasedEndpoints = names.map((name) =>`${options.api}/assets?collectionId=${collectionId}&name=${encodeURIComponent(name)}&projection=stigs`)
 
     let responses
-    const startTime = Date.now()
     try {
       responses = await apiGetRequestsParallel({
         endpoints: new Set(nameBasedEndpoints),
@@ -186,8 +185,6 @@ export async function getCollectionAssets({ collectionId, targets }) {
       }
       throw (e)
     }
-    const elapsedTime = Date.now() - startTime
-    console.log(`Fetched ${responses.length} assets in ${elapsedTime}ms`)
     const assets = []
     for (const response of responses) {
       logResponse (response)

--- a/lib/api.js
+++ b/lib/api.js
@@ -149,50 +149,8 @@ export async function getCollection(collectionId) {
 }
 
 export async function getCollectionAssets({collectionId, targets}) {
-
-  let namedEndpoints = []
-  let metadataEndpoints = []
-  
-  if (targets) {
-    const names = targets.filter(t => !t.metadata.cklHostName).map(t => t.name)
-    const cklMetadatas = targets.filter(t => t.metadata.cklHostName).map(t => (({cklHostName, cklWebDbSite, cklWebDbInstance}) => ({cklHostName, cklWebDbSite, cklWebDbInstance}))(t.metadata))
-
-    namedEndpoints = names.map(name => `${options.api}/assets?collectionId=${collectionId}&name=${encodeURIComponent(name)}&projection=stigs`)
-    metadataEndpoints = cklMetadatas.map(md => {
-      let metadataParams = []
-      for (const metadataKey of Object.keys(md).filter(k=>md[k])) {
-        metadataParams.push(`metadata=${metadataKey}%3A${encodeURIComponent(md[metadataKey])}`)
-      }
-      return `${options.api}/assets?collectionId=${collectionId}&${metadataParams.join('&')}&projection=stigs`
-    })
-    let responses
-    try {
-      responses = await apiGetRequestsParallel({
-        endpoints: new Set([...namedEndpoints, ...metadataEndpoints])
-      })
-    }
-    catch (e) {
-      logError(e)
-      if (e.response?.statusCode === 403) {
-        Alarm.noGrant(true)
-      }
-      else if (e.code !== 'ERR_NON_2XX_3XX_RESPONSE') {
-        Alarm.apiOffline(true)
-      }
-      throw (e)
-    }
-  
-    const assets = []
-    for (const response of responses) {
-      logResponse (response)
-      if (response.body?.[0]) assets.push(response.body[0])
-    }
-    return assets
-  }
-  else {
-    cache.assets = await apiRequest({endpoint: `/assets?collectionId=${collectionId}&projection=stigs`})
-    return cache.assets
-  }
+  cache.assets = await apiRequest({endpoint: `/assets?collectionId=${collectionId}&projection=stigs`})
+  return cache.assets
 }
 
 export async function getInstalledStigs() {

--- a/lib/api.js
+++ b/lib/api.js
@@ -152,50 +152,9 @@ export async function getCollection(collectionId) {
   return cache.collection
 }
 
-export async function getCollectionAssets({ collectionId, targets }) {
-  let nameBasedEndpoints = []
-
-  if (targets) {
-    const names = targets.map((t) => {
-      if (!t.metadata.cklHostName) {
-        // Plain name
-        return t.name
-      } else {
-        // Effective name if has ckl metadata 
-        return createEffectiveName(t.metadata)
-      }
-    })
-
-    // Create endpoints for each name to fetch assets by name
-    nameBasedEndpoints = names.map((name) =>`${options.api}/assets?collectionId=${collectionId}&name=${encodeURIComponent(name)}&projection=stigs`)
-
-    let responses
-    try {
-      responses = await apiGetRequestsParallel({
-        endpoints: new Set(nameBasedEndpoints),
-      })
-    }
-    catch (e) {
-      logError(e)
-      if (e.response?.statusCode === 403) {
-        Alarm.noGrant(true)
-      }
-      else if (e.code !== 'ERR_NON_2XX_3XX_RESPONSE') {
-        Alarm.apiOffline(true)
-      }
-      throw (e)
-    }
-    const assets = []
-    for (const response of responses) {
-      logResponse (response)
-      if (response.body?.[0]) assets.push(response.body[0])
-    }
-    return assets
-  }
-  else {
-    cache.assets = await apiRequest({endpoint: `/assets?collectionId=${collectionId}&projection=stigs`})
-    return cache.assets
-  }
+export async function getCollectionAssets({ collectionId }) {
+  cache.assets = await apiRequest({endpoint: `/assets?collectionId=${collectionId}&projection=stigs`})
+  return cache.assets
 }
 
 export async function getInstalledStigs() {

--- a/lib/api.js
+++ b/lib/api.js
@@ -128,6 +128,10 @@ async function apiGetRequestsParallel({endpoints, authorize = true}) {
   return Promise.all(requests)
 }
 
+function createEffectiveName(target) {
+  return `${target.cklHostName}-${target.cklWebDbSite ?? 'NA'}-${target.cklWebDbInstance ?? 'NA'}`
+}
+
 export async function getScapBenchmarkMap() {
   const body = await apiRequest({endpoint: '/stigs/scap-maps'})
   cache.scapBenchmarkMap = new Map(body.map(apiScapMap => [apiScapMap.scapBenchmarkId, apiScapMap.benchmarkId]))
@@ -148,9 +152,53 @@ export async function getCollection(collectionId) {
   return cache.collection
 }
 
-export async function getCollectionAssets({collectionId, targets}) {
-  cache.assets = await apiRequest({endpoint: `/assets?collectionId=${collectionId}&projection=stigs`})
-  return cache.assets
+export async function getCollectionAssets({ collectionId, targets }) {
+  let nameBasedEndpoints = []
+
+  if (targets) {
+    const names = targets.map((t) => {
+      if (!t.metadata.cklHostName) {
+        // Plain name
+        return t.name
+      } else {
+        // Effective name if has ckl metadata 
+        return createEffectiveName(t.metadata)
+      }
+    })
+
+    // Create endpoints for each name to fetch assets by name
+    nameBasedEndpoints = names.map((name) =>`${options.api}/assets?collectionId=${collectionId}&name=${encodeURIComponent(name)}&projection=stigs`)
+
+    let responses
+    const startTime = Date.now()
+    try {
+      responses = await apiGetRequestsParallel({
+        endpoints: new Set(nameBasedEndpoints),
+      })
+    }
+    catch (e) {
+      logError(e)
+      if (e.response?.statusCode === 403) {
+        Alarm.noGrant(true)
+      }
+      else if (e.code !== 'ERR_NON_2XX_3XX_RESPONSE') {
+        Alarm.apiOffline(true)
+      }
+      throw (e)
+    }
+    const elapsedTime = Date.now() - startTime
+    console.log(`Fetched ${responses.length} assets in ${elapsedTime}ms`)
+    const assets = []
+    for (const response of responses) {
+      logResponse (response)
+      if (response.body?.[0]) assets.push(response.body[0])
+    }
+    return assets
+  }
+  else {
+    cache.assets = await apiRequest({endpoint: `/assets?collectionId=${collectionId}&projection=stigs`})
+    return cache.assets
+  }
 }
 
 export async function getInstalledStigs() {

--- a/lib/api.js
+++ b/lib/api.js
@@ -128,10 +128,6 @@ async function apiGetRequestsParallel({endpoints, authorize = true}) {
   return Promise.all(requests)
 }
 
-function createEffectiveName(target) {
-  return `${target.cklHostName}-${target.cklWebDbSite ?? 'NA'}-${target.cklWebDbInstance ?? 'NA'}`
-}
-
 export async function getScapBenchmarkMap() {
   const body = await apiRequest({endpoint: '/stigs/scap-maps'})
   cache.scapBenchmarkMap = new Map(body.map(apiScapMap => [apiScapMap.scapBenchmarkId, apiScapMap.benchmarkId]))

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -99,12 +99,7 @@ async function resultsHandler( parsedResults, cb ) {
     batchId++
     const isModeScan = options.mode === 'scan'
     logger.info({component, message: `batch started`, batchId, size: parsedResults.length})
-    const apiAssets = await api.getCollectionAssets(
-      {
-        collectionId: options.collectionId,
-        targets: parsedResults.map(pr=>pr.target)
-      }
-    )
+    const apiAssets = await api.getCollectionAssets({collectionId: options.collectionId})
     logger.info({component, message: `asset data received`, batchId, size: apiAssets.length})
     const apiStigs = await api.getInstalledStigs()
     logger.info({component, message: `stig data received`, batchId, size: apiStigs.length})

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
-        "@nuwcdivnpt/stig-manager-client-modules": "^1.5.4",
+        "@nuwcdivnpt/stig-manager-client-modules": "^1.5.5",
         "atob": "^2.1.2",
         "better-queue": "^3.8.10",
         "chokidar": "^3.5.1",
@@ -554,9 +554,9 @@
       }
     },
     "node_modules/@nuwcdivnpt/stig-manager-client-modules": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@nuwcdivnpt/stig-manager-client-modules/-/stig-manager-client-modules-1.5.4.tgz",
-      "integrity": "sha512-dkq8FSKGgmaLPDRvkLciXxePgahq//W/fYxl0X2kSWM6KDgNFXUL7E71QusY5hD1tam4w0sOdUTWWXbagfq02Q==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@nuwcdivnpt/stig-manager-client-modules/-/stig-manager-client-modules-1.5.5.tgz",
+      "integrity": "sha512-t7g6YhFZCiQg4nOj9vKz+LwjtN5Q2vGxvRQD3ZCWDDr/r7EK54XyR0MjQbOd2vvzgKoxrkfp3DctLDiHgGzc8g==",
       "hasInstallScript": true
     },
     "node_modules/@sindresorhus/is": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@nuwcdivnpt/stig-manager-client-modules": "^1.5.4",
+    "@nuwcdivnpt/stig-manager-client-modules": "^1.5.5",
     "atob": "^2.1.2",
     "better-queue": "^3.8.10",
     "chokidar": "^3.5.1",


### PR DESCRIPTION
resolves part of [this issue ](https://github.com/orgs/NUWCDIVNPT/projects/3/views/8?pane=issue&itemId=112999150&issue=NUWCDIVNPT%7Cstig-manager-client-modules%7C43)
resolves #154 

This pull request refactors the `getCollectionAssets` function in `lib/api.js` to construct the 'effective name' of an asset with ckl metadata. This was needed because it is possible to have assets in the api with different names but equal ckl metadata values. 

### Refactoring for endpoint creation:

* [`lib/api.js`](diffhunk://#diff-3814d8caba69e5fdf3b23eed56ec7d708b8ede5aed6d686ac579421877938ec7L152-R176): Replaced separate named and metadata endpoint arrays with a unified `nameBasedEndpoints` array. The logic now uses a helper function, `createEffectiveName`, to generate effective names for targets with `ckl` metadata.

### Utility function addition:

* [`lib/api.js`](diffhunk://#diff-3814d8caba69e5fdf3b23eed56ec7d708b8ede5aed6d686ac579421877938ec7R131-R134): Added the `createEffectiveName` function to construct effective names for targets based on their metadata (`cklHostName`, `cklWebDbSite`, and `cklWebDbInstance`).
