### PR TITLE
feat: watcher will pause when stig manager is in maintenance mode.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ import { options, configValid }  from './lib/args.js'
 import * as CONSTANTS from './lib/consts.js'
 const minApiVersion = CONSTANTS.MIN_API_VERSION
 const component = 'index'
+let currentMode
 if (!configValid) {
   logger.error({ component, message: 'invalid configuration... Exiting'})
   logger.end()
@@ -16,7 +17,6 @@ import { serializeError } from 'serialize-error'
 import { initScanner } from './lib/scan.js'
 import semverGte from 'semver/functions/gte.js'
 import Alarm from './lib/alarm.js'
-
 
 
 process.on('SIGINT', () => {
@@ -59,9 +59,8 @@ async function run() {
       pid: process.pid,
       options: getObfuscatedConfig(options)
     })
-    
-    await preflightServices()
     setupAlarmHandlers()
+    await preflightServices()
     if (options.mode === 'events') {
       startFsEventWatcher()
     }
@@ -76,7 +75,23 @@ async function run() {
   }
 }
 
+/**
+ * Waits until the API returns to normal mode.
+ * This function will not resolve until `alarmLowered` fires.
+ */
+async function apiNotNormalGate() {
+  return new Promise((resolve) => {
+    const onLowered = (alarmType) => {
+      if (alarmType === 'apiNotNormal') {
+        resolve()
+      }
+    }
+    Alarm.on('alarmLowered', onLowered, { once: true})
+  })
+}
+
 function setupAlarmHandlers() {
+
   const alarmHandlers = {
     apiOffline: api.offlineRetryHandler,
     authOffline: auth.offlineRetryHandler,
@@ -123,7 +138,87 @@ async function hasMinApiVersion () {
   }
 }
 
+// count of EventSource reconnect attempts
+let esRetryCount = 0
+const esRetryLimit = 5
+
+/**
+ * Initializes the EventSource connection to the Stig Manager API server state event stream.
+ * Listens for 'state-report' and 'mode-changed' events to monitor the API mode.
+ * Raises or lowers the 'apiNotNormal' alarm based on the current mode.
+ */
+async function initEventSource() {
+  const es = await api.getAPIEventStream()
+  // Log when connection is established
+  es.onopen = () => logger.info({ component, message: 'Connected to Stig Manager API server state event' })
+
+  // Log and handle connection errors
+  es.onerror = (e) => {
+    logger.error({ component, message: 'Failed to connect to Stig Manager API state server side event.', error: e })
+    esRetryCount++
+      if (esRetryCount > esRetryLimit) {
+        logger.error({ component, message: `Stig Manager API event stream reconnect retry limit reached (${esRetryLimit}).` })
+        Alarm.shutdown(CONSTANTS.ERR_APIOFFLINE)
+      }
+  }
+
+  
+  /**
+   * Returns a Promise that resolves with the initial state payload received from a 'state-report' event.
+   * 
+   * The function listens for a single 'state-report' event from the EventSource `es`, parses the event data as JSON,
+   * logs the initial state, updates the current mode, triggers an alarm if the mode is not 'normal', and then resolves
+   * the Promise with the parsed payload.
+   *
+   */
+ const getInitialState = new Promise((resolve) => {
+    const onStart = (e) => {
+      let payload
+      try { 
+        payload = JSON.parse(e.data)
+      }
+      catch (err) {
+        logger.error({ component, message: 'Failed to get Stig Manager API mode.', error: err })
+        return
+      }
+      logger.info({ component, message: 'Stig Manager Initial State Report', state: payload })
+      currentMode = payload?.mode?.currentMode
+      Alarm.apiNotNormal(payload?.mode?.currentMode !== 'normal')
+      es.removeEventListener('state-report', onStart)
+      resolve(payload)
+    }
+    es.addEventListener('state-report', onStart, { once: true })
+  })
+  
+  // Handler for 'state-report' and 'mode-changed' events
+  const handleEvent = (e) => {
+    let payload 
+    try {
+      payload = JSON.parse(e.data)
+    }
+    catch (err) {
+      logger.error({ component, message: 'Failed to get Stig Manager API mode.', error: err })
+      return
+    }
+    if(payload?.mode?.currentMode !== currentMode) {
+      currentMode = payload?.mode?.currentMode
+      logger.info({ component, message: 'Stig Manager Mode Changed', state: payload })
+    }
+    Alarm.apiNotNormal(payload?.mode?.currentMode !== 'normal')
+  }
+  // wait for the initial state before adding event listeners
+  await getInitialState
+
+  es.addEventListener('state-report', handleEvent)
+  es.addEventListener('mode-changed', handleEvent)
+}
+
 async function preflightServices () {
+  await initEventSource()
+  // block here until api is in normal mode so we continue with preflights 
+  if (Alarm.isAlarmed()) {
+    await apiNotNormalGate()
+  }
   await hasMinApiVersion()
   await auth.getOpenIDConfiguration()
   await auth.getToken()

--- a/index.js
+++ b/index.js
@@ -140,8 +140,15 @@ async function hasMinApiVersion () {
 }
 
 async function hasSSEEndpoint() {
-  const [sseEndpoint] = await api.getDefinition('$.paths./op/state/sse')
-  return !!sseEndpoint
+  try {
+    const [sseEndpoint] = await api.getDefinition('$.paths./op/state/sse')
+    return !!sseEndpoint
+  }
+  catch (e) {
+    logger.warn({ component, message: 'failed to determine if api has sse endpoint. assuming it does not.', error: e })
+    return false
+  }
+ 
 }
 
 // count of EventSource reconnect attempts

--- a/lib/alarm.js
+++ b/lib/alarm.js
@@ -5,12 +5,13 @@ import { EventEmitter } from "node:events"
  * @typedef {Object} Alarms
  * @property {boolean} apiOffline - the STIG manager API is unreachable.
  * @property {boolean} authOffline - the OIDC IdP is unreachable.
+ * @property {boolean} apiNotNormal - the STIG manager API is reachable but is not in 'normal' state.
  * @property {boolean} noToken - the OIDC IdP did not issue the client a token.
  * @property {boolean} noGrant - the client has an insufficient grant on the configured Collection.
  */
 
 /**
- * @typedef {'apiOffline' | 'authOffline' | 'noToken' | 'noGrant'} AlarmType 
+ * @typedef {'apiOffline' | 'authOffline' | 'noToken' | 'noGrant' | 'apiNotNormal'} AlarmType 
  */
 
 class Alarm extends EventEmitter {
@@ -21,6 +22,7 @@ class Alarm extends EventEmitter {
         super()
         this.#alarms = {
             apiOffline: false,
+            apiNotNormal: false,
             authOffline: false,
             noToken: false,
             noGrant: false,
@@ -54,6 +56,17 @@ class Alarm extends EventEmitter {
         if (this.#alarms.apiOffline === state) return
         this.#alarms.apiOffline = state
         this.#emitAlarmEvent( 'apiOffline', state)
+    }
+
+    /**
+     * Sets the state of the apiNotNormal alarm
+     * and emits an alarmRaised or alarmLowered event
+     * @param {boolean} state
+     */
+    apiNotNormal (state) {
+        if (this.#alarms.apiNotNormal === state) return
+        this.#alarms.apiNotNormal = state
+        this.#emitAlarmEvent( 'apiNotNormal', state)
     }
 
     /**

--- a/lib/api.js
+++ b/lib/api.js
@@ -4,7 +4,7 @@ import { getToken, tokens } from './auth.js'
 import { logger, getSymbol } from './logger.js'
 import Alarm from './alarm.js'
 import * as CONSTANTS from './consts.js'
-
+import { EventSource } from 'eventsource'
 const component = 'api'
 const cache = {
   collection: null,
@@ -142,6 +142,13 @@ async function getDefinition(jsonPath) {
   return cache.definition
 }
 export {getDefinition}
+
+export async function getAPIEventStream(){
+  const url = `${options.api.replace(/\/+$/, '')}/op/state/sse`
+  const esOptions = {}
+  const es = new EventSource(url, esOptions)
+  return es
+}
 
 export async function getCollection(collectionId) {
   cache.collection = await apiRequest({endpoint: `/collections/${collectionId}`})

--- a/lib/api.js
+++ b/lib/api.js
@@ -144,7 +144,7 @@ async function getDefinition(jsonPath) {
 export {getDefinition}
 
 export async function getAPIEventStream(){
-  const url = `${options.api.replace(/\/+$/, '')}/op/state/sse`
+  const url = `${options.api}/op/state/sse`
   const esOptions = {}
   const es = new EventSource(url, esOptions)
   return es

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "chokidar": "^3.5.1",
         "commander": "^7.2.0",
         "dotenv": "^8.2.0",
+        "eventsource": "^4.0.0",
         "fast-glob": "^3.3.2",
         "got": "^11.8.2",
         "jsonwebtoken": "^9.0.0",
@@ -1188,6 +1189,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.0.0.tgz",
+      "integrity": "sha512-fvIkb9qZzdMxgZrEQDyll+9oJsyaVvY92I2Re+qK0qEJ+w5s0X3dtz+M0VAPOjP1gtU3iqWyjQ0G3nvd5CLZ2g==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.5.tgz",
+      "integrity": "sha512-bSRG85ZrMdmWtm7qkF9He9TNRzc/Bm99gEJMaQoHJ9E6Kv9QBbsldh2oMj7iXmYNEAVvNgvv5vPorG6W+XtBhQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/fast-glob": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "chokidar": "^3.5.1",
     "commander": "^7.2.0",
     "dotenv": "^8.2.0",
+    "eventsource": "^4.0.0",
     "fast-glob": "^3.3.2",
     "got": "^11.8.2",
     "jsonwebtoken": "^9.0.0",


### PR DESCRIPTION
resolves #158 

This pull request introduces a mechanism to monitor and respond to the operational mode of the Stig Manager API using server-sent events (SSE). It adds a new "apiNotNormal" alarm state, ensures the application waits for the API to return to "normal" mode before proceeding with startup tasks, and improves error handling and logging around API state monitoring. The changes also include the addition of the `eventsource` dependency for SSE support.

**API Mode Monitoring and Alarm Handling:**

* Added a new `apiNotNormal` alarm type to the `Alarm` system, with methods to raise and lower this alarm and emit corresponding events. (`lib/alarm.js`)
* Implemented `initEventSource` in `index.js` to establish an SSE connection to the API, listen for mode changes, and update the `apiNotNormal` alarm accordingly. The function handles connection retries and triggers a shutdown if the retry limit is reached. (`index.js`)
* Added a gate (`apiNotNormalGate`) that blocks further initialization until the API returns to "normal" mode, ensuring that startup proceeds only when the API is ready. (`index.js`) 
**Integration with Startup Flow:**

* Modified the startup sequence to initialize the event source and wait for the API to become "normal" before continuing with preflight checks. (`index.js`) 
**Dependency and Utility Updates:**

* Added the `eventsource` package to `package.json` and imported it in `lib/api.js` to support SSE connections. (`package.json`, `lib/api.js`)
* Added `getAPIEventStream` utility in `lib/api.js` to create and return an EventSource instance for the API state SSE endpoint. (`lib/api.js`)

These changes collectively improve the application's resilience and awareness of the API's operational state, preventing operations from proceeding when the API is not ready.