### PR TITLE
Out of memory issue

### DIFF
--- a/.github/workflows/backpressure.yml
+++ b/.github/workflows/backpressure.yml
@@ -1,0 +1,35 @@
+name: Backpressure Test
+on:
+  workflow_dispatch:
+  push:
+    branches:
+        - main
+    paths:
+        - "lib/**"
+        - "index.js"
+        - "test/**"
+        - ".github/workflows/backpressure.yml"
+  pull_request:
+    branches:
+        - main
+    paths:
+        - "lib/**"
+        - "index.js"
+        - "test/**"
+        - ".github/workflows/backpressure.yml"
+jobs:
+  backpressure:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20.x"
+    - name: Install app dependencies
+      run: npm ci
+    - name: Create .env file
+      run: echo -e "WATCHER_COLLECTION=1\nWATCHER_API_BASE=url\nWATCHER_AUTHORITY=auth\nWATCHER_CLIENT_ID=clientId\nWATCHER_CLIENT_SECRET=secret" > .env
+    - name: Run backpressure test
+      run: npx mocha test/e2e/backpressure.test.js --file test/e2e/env.js --timeout 300000

--- a/.github/workflows/backpressure.yml
+++ b/.github/workflows/backpressure.yml
@@ -32,4 +32,6 @@ jobs:
     - name: Create .env file
       run: echo -e "WATCHER_COLLECTION=1\nWATCHER_API_BASE=url\nWATCHER_AUTHORITY=auth\nWATCHER_CLIENT_ID=clientId\nWATCHER_CLIENT_SECRET=secret" > .env
     - name: Run backpressure test
-      run: npx mocha test/e2e/backpressure.test.js
+      run: |
+        echo '{"spec":"test/e2e/backpressure.test.js","file":["test/e2e/env.js"]}' > .mocharc.json
+        npx mocha

--- a/.github/workflows/backpressure.yml
+++ b/.github/workflows/backpressure.yml
@@ -32,4 +32,4 @@ jobs:
     - name: Create .env file
       run: echo -e "WATCHER_COLLECTION=1\nWATCHER_API_BASE=url\nWATCHER_AUTHORITY=auth\nWATCHER_CLIENT_ID=clientId\nWATCHER_CLIENT_SECRET=secret" > .env
     - name: Run backpressure test
-      run: npx mocha test/e2e/backpressure.test.js --file test/e2e/env.js --timeout 300000
+      run: npx mocha test/e2e/backpressure.test.js --timeout 300000

--- a/.github/workflows/backpressure.yml
+++ b/.github/workflows/backpressure.yml
@@ -32,4 +32,4 @@ jobs:
     - name: Create .env file
       run: echo -e "WATCHER_COLLECTION=1\nWATCHER_API_BASE=url\nWATCHER_AUTHORITY=auth\nWATCHER_CLIENT_ID=clientId\nWATCHER_CLIENT_SECRET=secret" > .env
     - name: Run backpressure test
-      run: npx mocha test/e2e/backpressure.test.js --timeout 300000
+      run: npx mocha test/e2e/backpressure.test.js

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,5 @@
 {
   "extension": ["js"],
-  "spec": "test/**/*.test.js",
+  "spec": ["test/scan/**/*.test.js", "test/e2e/e2e.test.js"],
   "file": ["test/e2e/env.js"]
 }

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,6 @@
 {
   "extension": ["js"],
-  "spec": ["test/scan/**/*.test.js", "test/e2e/e2e.test.js"],
+  "spec": "test/**/*.test.js",
+  "ignore": ["test/e2e/backpressure.test.js"],
   "file": ["test/e2e/env.js"]
 }

--- a/lib/args.js
+++ b/lib/args.js
@@ -83,7 +83,7 @@ program
 .addOption(logLevelOption)
 .addOption(logFileLevelOption)
 .addOption(modeOption)
-.option('--history-file <path>', 'If `--mode scan`, the path to a scan history file (`WATCHER_HISTORY_FILE`). Will be created if needed, ignored if `--mode events`, disabled with `--no-history-file`. A line is written for each file discovered by the scanner and the scanner ignores any existing entries.', pe.WATCHER_HISTORY_FILE ?? false)
+.option('--history-file <path>', 'If `--mode scan`, the path to a scan history file (`WATCHER_HISTORY_FILE`). Will be created if needed, ignored if `--mode events`, disabled with `--no-history-file`. A line is written for each file discovered by the scanner and the scanner ignores any existing entries.', pe.WATCHER_HISTORY_FILE ?? './watcher-history.txt')
 .option('--no-history-file', 'If `--mode scan`, disable the scan history file.')
 .option('--log-file <path>', 'Path to the log file which will be created if needed (`WATCHER_LOG_FILE`). Disable file logging with `--no-log-file`.', pe.WATCHER_LOG_FILE ?? false)
 .option('--no-log-file', 'Disable logging to a logfile.')

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -105,7 +105,7 @@ async function resultsHandler( parsedResults, cb ) {
     if (!Array.isArray(parsedResults)) {
       parsedResults = [parsedResults]
     }
-    logger.info({component, message: `batch started`, batchId, size: parsedResults.length})
+    logger.info({component, message: `batch started`, batchId, size: parsedResults.length, cargoDepth: cargoQueue._store._queue.length})
     const apiAssets = await api.getCollectionAssets({collectionId: options.collectionId})
     logger.info({component, message: `asset data received`, batchId, size: apiAssets.length})
     const apiStigs = await api.getInstalledStigs()
@@ -118,7 +118,7 @@ async function resultsHandler( parsedResults, cb ) {
         isModeScan && success && addToHistory(taskAsset.sourceRefs)
       }
     }
-    logger.info({component, message: 'batch ended', batchId})
+    logger.info({component, message: 'batch ended', batchId, cargoDepth: cargoQueue._store._queue.length})
     cb()
   }
   catch (e) {

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -105,7 +105,7 @@ async function resultsHandler( parsedResults, cb ) {
     if (!Array.isArray(parsedResults)) {
       parsedResults = [parsedResults]
     }
-    logger.info({component, message: `batch started`, batchId, size: parsedResults.length, cargoDepth: cargoQueue._store._queue.length})
+    logger.info({component, message: `batch started`, batchId, size: parsedResults.length, cargoDepth: cargoQueue.length})
     const apiAssets = await api.getCollectionAssets({collectionId: options.collectionId})
     logger.info({component, message: `asset data received`, batchId, size: apiAssets.length})
     const apiStigs = await api.getInstalledStigs()
@@ -118,7 +118,7 @@ async function resultsHandler( parsedResults, cb ) {
         isModeScan && success && addToHistory(taskAsset.sourceRefs)
       }
     }
-    logger.info({component, message: 'batch ended', batchId, cargoDepth: cargoQueue._store._queue.length})
+    logger.info({component, message: 'batch ended', batchId, cargoDepth: cargoQueue.length})
     cb()
   }
   catch (e) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -9,6 +9,8 @@ import { options } from './args.js'
 import Alarm from './alarm.js'
 
 const component = 'parser'
+const cargoHighWaterMark = 2 * options.cargoSize
+
 const defaultImportOptions = {
   autoStatus: 'saved',
   unreviewed: 'commented',
@@ -33,6 +35,40 @@ function canUserAccept () {
   const apiCollection = cache.collection
   const userGrant = cache.user.collectionGrants.find( i => i.collection.collectionId === apiCollection.collectionId )?.roleId
   return apiCollection.settings.status.canAccept && (userGrant >= apiCollection.settings.status.minAcceptGrant)
+}
+
+/**
+ * Returns the current number of tasks waiting in the cargoQueue store.
+ */
+function getCargoDepth () {
+  return cargoQueue._store._queue.length
+}
+
+/**
+ * Returns a Promise that resolves when cargoQueue depth drops at or below
+ * the threshold, or when an alarm is raised (to avoid deadlock).
+ */
+function waitForCargoBelow (threshold) {
+  return new Promise((resolve) => {
+    const checkDepth = () => {
+      if (getCargoDepth() <= threshold) {
+        cargoQueue.removeListener('batch_finish', onBatchFinish)
+        Alarm.removeListener('alarmRaised', onAlarm)
+        resolve()
+      }
+    }
+    const onBatchFinish = () => {
+      checkDepth()
+    }
+    const onAlarm = () => {
+      cargoQueue.removeListener('batch_finish', onBatchFinish)
+      Alarm.removeListener('alarmRaised', onAlarm)
+      resolve()
+    }
+    cargoQueue.on('batch_finish', onBatchFinish)
+    Alarm.on('alarmRaised', onAlarm)
+    checkDepth()
+  })
 }
 
 async function parseFileAndEnqueue (file, cb) {
@@ -80,8 +116,18 @@ async function parseFileAndEnqueue (file, cb) {
         stats: checklist.stats
       })
     }
-    logger.verbose({component, message: `results queued`, file: parseResult.sourceRef, 
+    logger.verbose({component, message: `results queued`, file: parseResult.sourceRef,
       target: parseResult.target.name, checklists: checklistInfo })
+
+    // Backpressure: if cargoQueue depth exceeds the high-water mark,
+    // wait for it to drain before signaling completion to parseQueue.
+    if (getCargoDepth() > cargoHighWaterMark) {
+      logger.verbose({component, message: `backpressure active, waiting for cargo to drain`,
+        cargoDepth: getCargoDepth(), cargoHighWaterMark})
+      await waitForCargoBelow(cargoHighWaterMark)
+      logger.verbose({component, message: `backpressure released`,
+        cargoDepth: getCargoDepth()})
+    }
     cb(null, parseResult)
   }
   catch (e) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -38,10 +38,10 @@ function canUserAccept () {
 }
 
 /**
- * Returns the current number of tasks waiting in the cargoQueue store.
+ * Returns the current number of tasks queued in the cargoQueue.
  */
 function getCargoDepth () {
-  return cargoQueue._store._queue.length
+  return cargoQueue.length
 }
 
 /**
@@ -50,22 +50,32 @@ function getCargoDepth () {
  */
 function waitForCargoBelow (threshold) {
   return new Promise((resolve) => {
+    const cleanup = () => {
+      cargoQueue.removeListener('batch_finish', onBatch)
+      cargoQueue.removeListener('batch_failed', onBatch)
+      cargoQueue.removeListener('drain', onDrain)
+      Alarm.removeListener('alarmRaised', onAlarm)
+    }
     const checkDepth = () => {
       if (getCargoDepth() <= threshold) {
-        cargoQueue.removeListener('batch_finish', onBatchFinish)
-        Alarm.removeListener('alarmRaised', onAlarm)
+        cleanup()
         resolve()
       }
     }
-    const onBatchFinish = () => {
+    const onBatch = () => {
       checkDepth()
     }
-    const onAlarm = () => {
-      cargoQueue.removeListener('batch_finish', onBatchFinish)
-      Alarm.removeListener('alarmRaised', onAlarm)
+    const onDrain = () => {
+      cleanup()
       resolve()
     }
-    cargoQueue.on('batch_finish', onBatchFinish)
+    const onAlarm = () => {
+      cleanup()
+      resolve()
+    }
+    cargoQueue.on('batch_finish', onBatch)
+    cargoQueue.on('batch_failed', onBatch)
+    cargoQueue.on('drain', onDrain)
     Alarm.on('alarmRaised', onAlarm)
     checkDepth()
   })
@@ -175,9 +185,3 @@ function onAlarmLowered (alarmType) {
   })
   parseQueue.resume()
 }
-
-
-
-
-
-  

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
-        "@nuwcdivnpt/stig-manager-client-modules": "^1.6.0",
+        "@nuwcdivnpt/stig-manager-client-modules": "^1.6.1",
         "atob": "^2.1.2",
         "better-queue": "^3.8.10",
         "chokidar": "^3.5.1",
@@ -30,7 +30,7 @@
         "c8": "^10.1.3",
         "chai": "^6.0.1",
         "esbuild": "^0.25.9",
-        "mocha": "^11.7.4",
+        "mocha": "11.3.0",
         "testcontainers": "^11.5.1"
       },
       "engines": {
@@ -671,10 +671,9 @@
       }
     },
     "node_modules/@nuwcdivnpt/stig-manager-client-modules": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@nuwcdivnpt/stig-manager-client-modules/-/stig-manager-client-modules-1.6.0.tgz",
-      "integrity": "sha512-V0Y+5cN5jyPxjJEsltbnLxodbWPFXELa1eOMGtHsVuisNqzbIM2Qvqv3Gya1TgF0LJIfNl9nEXdhuStO8dkHCg==",
-      "hasInstallScript": true,
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@nuwcdivnpt/stig-manager-client-modules/-/stig-manager-client-modules-1.6.1.tgz",
+      "integrity": "sha512-yeo2W+5XJZsKfVBPNiT2wGIFabwkvgcNVdURnT2DSiID5ZBWh5/refdwkVA91qZiqw36zSqVLxKZ8GTIpmNrKQ==",
       "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
@@ -854,9 +853,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.0.tgz",
-      "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
+      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1832,9 +1831,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -2268,6 +2267,7 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2295,6 +2295,22 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/got": {
@@ -2452,16 +2468,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-plain-obj": {
@@ -2868,19 +2874,16 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">=10"
       }
     },
     "node_modules/minipass": {
@@ -2914,30 +2917,29 @@
       "license": "MIT"
     },
     "node_modules/mocha": {
-      "version": "11.7.5",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
-      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.3.0.tgz",
+      "integrity": "sha512-J0RLIM89xi8y6l77bgbX+03PeBRDQCOVQpnwOcCN7b8hCmbh6JvGI2ZDJ5WMoHz+IaPU+S4lvTd0j51GmBAdgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",
         "debug": "^4.3.5",
-        "diff": "^7.0.0",
+        "diff": "^5.2.0",
         "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
         "glob": "^10.4.5",
         "he": "^1.2.0",
-        "is-path-inside": "^3.0.3",
         "js-yaml": "^4.1.0",
         "log-symbols": "^4.1.0",
-        "minimatch": "^9.0.5",
+        "minimatch": "^5.1.6",
         "ms": "^2.1.3",
         "picocolors": "^1.1.1",
         "serialize-javascript": "^6.0.2",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
-        "workerpool": "^9.2.0",
+        "workerpool": "^6.5.1",
         "yargs": "^17.7.2",
         "yargs-parser": "^21.1.1",
         "yargs-unparser": "^2.0.0"
@@ -3331,19 +3333,6 @@
         "minimatch": "^5.1.0"
       }
     },
-    "node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3464,9 +3453,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3785,6 +3774,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/testcontainers": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-11.11.0.tgz",
@@ -3876,9 +3881,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.2.tgz",
-      "integrity": "sha512-4VQSpGEGsWzk0VYxyB/wVX/Q7qf9t5znLRgs0dzszr9w9Fej/8RVNQ+S20vdXSAyra/bJ7ZQfGv6ZMj7UEbzSg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.21.0.tgz",
+      "integrity": "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4006,9 +4011,9 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "9.3.4",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
-      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
       "dev": true,
       "license": "Apache-2.0"
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@nuwcdivnpt/stig-manager-client-modules": "^1.6.0",
+    "@nuwcdivnpt/stig-manager-client-modules": "^1.6.1",
     "atob": "^2.1.2",
     "better-queue": "^3.8.10",
     "chokidar": "^3.5.1",
@@ -37,7 +37,7 @@
     "c8": "^10.1.3",
     "chai": "^6.0.1",
     "esbuild": "^0.25.9",
-    "mocha": "^11.7.4",
+    "mocha": "11.3.0",
     "testcontainers": "^11.5.1"
   }
 }

--- a/test/e2e/backpressure.test.js
+++ b/test/e2e/backpressure.test.js
@@ -24,8 +24,8 @@ describe("backpressure: bounded cargo depth under load", function () {
     mode: "scan",
     historyFile: "test/e2e/bp-history.txt",
     responseTimeout: 10000,
-    historyWriteInterval: 5000,
-    cargoDelay: 100,
+    historyWriteInterval: 10000,
+    cargoDelay: 2000,
     logLevel: "verbose",
     cargoSize: CARGO_SIZE,
   }
@@ -60,6 +60,7 @@ describe("backpressure: bounded cargo depth under load", function () {
     watcher = await lib.runWatcherPromise({
       entry: "index.js",
       env,
+      consoleLog: true,
       resolveOnClose: true,
       resolveOnMessage: `received shutdown event with code 0, exiting`
     })

--- a/test/e2e/backpressure.test.js
+++ b/test/e2e/backpressure.test.js
@@ -1,0 +1,102 @@
+import { expect } from "chai"
+import * as lib from "./lib.js"
+import fs from 'fs'
+import path from 'node:path'
+
+const BASE_CKL_PATH = "test/e2e/testFiles/test.ckl"
+const BP_FILES_DIR = "test/e2e/bpFiles"
+const FILE_COUNT = 200
+const CARGO_SIZE = 5
+
+describe("backpressure: bounded cargo depth under load", function () {
+  this.timeout(300_000)
+  let db, auth, api
+  let watcher
+
+  const env = {
+    apiBase: "http://localhost:54001/api",
+    authority: "http://localhost:8080",
+    collectionId: "1",
+    clientId: "stigman-watcher",
+    clientSecret: "954fd71a-dad6-47ab-8035-060268f3d396",
+    path: BP_FILES_DIR,
+    oneShot: true,
+    mode: "scan",
+    historyFile: "test/e2e/bp-history.txt",
+    responseTimeout: 10000,
+    historyWriteInterval: 5000,
+    cargoDelay: 100,
+    logLevel: "verbose",
+    cargoSize: CARGO_SIZE,
+  }
+
+  before(async function () {
+    // create bpFiles directory
+    if (!fs.existsSync(BP_FILES_DIR)) {
+      fs.mkdirSync(BP_FILES_DIR, { recursive: true })
+    }
+
+    // generate CKL files with unique hostnames
+    const promises = []
+    for (let i = 0; i < FILE_COUNT; i++) {
+      const hostName = `bp-host-${String(i).padStart(4, '0')}`
+      const outputPath = path.join(BP_FILES_DIR, `${hostName}.ckl`)
+      promises.push(lib.createCkl(BASE_CKL_PATH, outputPath, hostName))
+    }
+    await Promise.all(promises)
+
+    // start infrastructure
+    await lib.clearHistoryFileContents(env.historyFile)
+    await lib.initNetwork()
+    db = await lib.startDb()
+    auth = await lib.startAuth()
+    api = await lib.startApi()
+
+    const { collection } = await lib.initWatcherTestCollection()
+    env.collectionId = collection.collectionId
+    await lib.uploadTestStig('VPN_STIG.xml')
+
+    // run watcher and wait for it to finish
+    watcher = await lib.runWatcherPromise({
+      entry: "index.js",
+      env,
+      resolveOnClose: true,
+      resolveOnMessage: `received shutdown event with code 0, exiting`
+    })
+  })
+
+  after(async function () {
+    lib.stopProcesses([api, auth, db])
+    await lib.clearDirectory(BP_FILES_DIR)
+    await lib.clearHistoryFileContents(env.historyFile)
+  })
+
+  it("should process all files successfully", function () {
+    expect(
+      watcher.logRecords.some(r => r.message === 'finished one shot mode')
+    ).to.be.true
+  })
+
+  it("should have processed multiple batches", function () {
+    const batchRecords = watcher.logRecords.filter(
+      r => r.component === 'cargo' && r.message === 'batch started'
+    )
+    expect(batchRecords.length).to.be.at.least(10)
+  })
+
+  it("should keep cargoDepth bounded", function () {
+    const batchRecords = watcher.logRecords.filter(
+      r => r.component === 'cargo' && r.message === 'batch started'
+    )
+    const depths = batchRecords.map(r => r.cargoDepth)
+    const maxDepth = Math.max(...depths)
+
+    // With backpressure, max depth should be bounded to roughly
+    // 2 * cargoSize (high-water mark) + headroom for concurrent parsers
+    const bound = 2 * CARGO_SIZE + 20
+    expect(maxDepth).to.be.at.most(
+      bound,
+      `max cargoDepth ${maxDepth} exceeded bound ${bound} (depths: ${depths.join(', ')})`
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Fixes NUWCDIVNPT/stigman-watcher#196 — JavaScript heap OOM when processing large numbers of CKL files.

- **Backpressure mechanism** (`lib/parse.js`): When cargoQueue depth exceeds `2 * cargoSize` (the high-water mark), parse workers delay their completion callback until the queue drains. This bounds memory to ~`cargoHighWaterMark + 8` parsed results in flight, preventing unbounded accumulation.
- **Cargo depth logging** (`lib/cargo.js`): Added `cargoDepth` to `batch started` and `batch ended` log lines for observability.
- **History file default** (`lib/args.js`): Changed scan mode history file default from `false` to `./watcher-history.txt` so scan mode always tracks processed files.
- Updates Dependencies

## How it works

The parseQueue (concurrency 8, CPU-bound) produces parsed results much faster than the cargoQueue (network-bound, batched API calls) can consume them. Without backpressure, all parsed results queue up in memory — at 186K files this causes OOM.

The fix delays `cb()` in `parseFileAndEnqueue` when `cargoQueue.length > 2 * cargoSize`. This keeps the parse worker slot "busy" from better-queue's perspective, naturally throttling the parse rate. The wait resolves on `batch_finish`, `batch_failed`, `drain`, or `alarmRaised` (deadlock escape).

## Test plan

- [x] Stress tested with 20K+ CKL files against full API stack — cargo depth stays bounded at ~`2 * cargoSize`  (simplified/smaller e2e backpressure test included)
- [x] Existing unit tests pass (`test/scan/historyfile.test.js`)
