### PR TITLE
feat: add option WATCHER_REQUEST_SCOPE to set literal scope

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -92,6 +92,7 @@ program
 .requiredOption('--client-id <string>', 'OIDC clientId to authenticate (`WATCHER_CLIENT_ID`). You will be prompted for the client secret if `--client-key` is not present and `--prompt` is present, unless `WATCHER_CLIENT_SECRET` is set', pe.WATCHER_CLIENT_ID)
 .option('--scope-prefix <string>', 'String used as a prefix for default stig-manager scopes (except `openid`) when authenticating to the OIDC Provider.',  pe.WATCHER_SCOPE_PREFIX ?? '')
 .option('--extra-scopes <string>', 'Space separated OAuth2 scopes to request in addition to the default scopes. Will not be automatically prefixed with WATCHER_SCOPE_PREFIX value.',  pe.WATCHER_EXTRA_SCOPES)
+.option('--request-scope <string>', 'Scope used for the token request (`WATCHER_REQUEST_SCOPE`). Overrides any value provided by WATCHER_SCOPE_PREFIX or WATCHER_EXTRA_SCOPES.', pe.WATCHER_REQUEST_SCOPE ?? '')
 .option('--client-key <path>', 'Path to a PEM encoded private key (`WATCHER_CLIENT_KEY`). If the key is encrypted, you will be prompted for the passphrase if `--prompt` is present, unless `WATCHER_CLIENT_KEY_PASSPHRASE` is set.',  pe.WATCHER_CLIENT_KEY)
 .option('--add-existing', 'For `--mode events`, existing files in the path will generate an `add` event (`WATCHER_ADD_EXISTING=1`). Ignored if `--mode scan`, negate with `--no-add-existing`.',  getBoolean('WATCHER_ADD_EXISTING', false))
 .option('--no-add-existing', 'Ignore existing files in the watched path (`WATCHER_ADD_EXISTING=0`).')

--- a/lib/args.js
+++ b/lib/args.js
@@ -92,7 +92,7 @@ program
 .requiredOption('--client-id <string>', 'OIDC clientId to authenticate (`WATCHER_CLIENT_ID`). You will be prompted for the client secret if `--client-key` is not present and `--prompt` is present, unless `WATCHER_CLIENT_SECRET` is set', pe.WATCHER_CLIENT_ID)
 .option('--scope-prefix <string>', 'String used as a prefix for default stig-manager scopes (except `openid`) when authenticating to the OIDC Provider.',  pe.WATCHER_SCOPE_PREFIX ?? '')
 .option('--extra-scopes <string>', 'Space separated OAuth2 scopes to request in addition to the default scopes. Will not be automatically prefixed with WATCHER_SCOPE_PREFIX value.',  pe.WATCHER_EXTRA_SCOPES)
-.option('--request-scope <string>', 'Scope used for the token request (`WATCHER_REQUEST_SCOPE`). Overrides any value provided by WATCHER_SCOPE_PREFIX or WATCHER_EXTRA_SCOPES.', pe.WATCHER_REQUEST_SCOPE ?? '')
+.option('--request-scope <string>', 'Scope used for the token request (`WATCHER_REQUEST_SCOPE`). Overrides any value provided by WATCHER_SCOPE_PREFIX or WATCHER_EXTRA_SCOPES.', pe.WATCHER_REQUEST_SCOPE)
 .option('--client-key <path>', 'Path to a PEM encoded private key (`WATCHER_CLIENT_KEY`). If the key is encrypted, you will be prompted for the passphrase if `--prompt` is present, unless `WATCHER_CLIENT_KEY_PASSPHRASE` is set.',  pe.WATCHER_CLIENT_KEY)
 .option('--add-existing', 'For `--mode events`, existing files in the path will generate an `add` event (`WATCHER_ADD_EXISTING=1`). Ignored if `--mode scan`, negate with `--no-add-existing`.',  getBoolean('WATCHER_ADD_EXISTING', false))
 .option('--no-add-existing', 'Ignore existing files in the watched path (`WATCHER_ADD_EXISTING=0`).')

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -15,14 +15,12 @@ self.key = options.clientKey
 self.authenticateFn = options.clientKey ? authenticateSignedJwt : authenticateClientSecret
 self.authentication = options.clientKey ? 'signed-jwt' : 'client-secret'
 
-const scopePrefix = options.scopePrefix
-
-const scopeArray= [
-  `${scopePrefix}stig-manager:stig:read`,
-  `${scopePrefix}stig-manager:collection`,
-  `${scopePrefix}stig-manager:user:read`,
+const scopeArray = options.requestScope ? [options.requestScope] : [
+  `${options.scopePrefix}stig-manager:stig:read`,
+  `${options.scopePrefix}stig-manager:collection`,
+  `${options.scopePrefix}stig-manager:user:read`,
 ]
-if (options.extraScopes) {
+if (options.extraScopes && !options.requestScope) {
   scopeArray.push(...options.extraScopes.split(" "))
 }
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -15,12 +15,13 @@ self.key = options.clientKey
 self.authenticateFn = options.clientKey ? authenticateSignedJwt : authenticateClientSecret
 self.authentication = options.clientKey ? 'signed-jwt' : 'client-secret'
 
-const scopeArray = options.requestScope ? [options.requestScope] : [
+const requestScope = options.requestScope?.trim() || undefined
+const scopeArray = requestScope ? [requestScope] : [
   `${options.scopePrefix}stig-manager:stig:read`,
   `${options.scopePrefix}stig-manager:collection`,
   `${options.scopePrefix}stig-manager:user:read`,
 ]
-if (options.extraScopes && !options.requestScope) {
+if (options.extraScopes && !requestScope) {
   scopeArray.push(...options.extraScopes.split(" "))
 }
 

--- a/test/e2e/e2e.test.js
+++ b/test/e2e/e2e.test.js
@@ -2440,6 +2440,7 @@ describe("setup and teardown", function () {
           watcher.process.kill()
         }
       } catch (e) {}
+      lib.stopProcesses([api, auth, db])
     })
 
     it('starts running and begins watching', async () => {
@@ -2589,6 +2590,11 @@ describe("setup and teardown", function () {
     })
 
     after(async () => {
+      try {
+        if (watcher && watcher.process) {
+          watcher.process.kill()
+        }
+      } catch (e) {}
       lib.stopProcesses([api, auth, db])
     })
 

--- a/test/e2e/e2e.test.js
+++ b/test/e2e/e2e.test.js
@@ -2551,5 +2551,69 @@ describe("setup and teardown", function () {
     })
 
   })
+
+  describe("One shot mode with WATCHER_REQUEST_SCOPE set", async function () {
+    this.timeout(120_000)
+    let db, auth, api
+    let watcher
+
+    const env = {
+      apiBase: "http://localhost:54001/api",
+      authority: `http://localhost:8080`,
+      collectionId: "1",
+      clientId: "stigman-watcher",
+      clientSecret: "954fd71a-dad6-47ab-8035-060268f3d396",
+      path: "test/e2e/scrapFiles",
+      oneShot: true,
+      mode: "scan",
+      historyFile: "test/e2e/e2e-history.txt",
+      responseTimeout: 10000,
+      historyWriteInterval: 10000,
+      scanInterval: 60000,
+      cargoDelay: 7000,
+      logLevel: "verbose",
+      cargoSize: 15,
+      requestScope: "api://test-app-id/.default",
+      extraScopes: "stig-manager:extra-scope"
+    }
+
+    before(async () => {
+      await lib.clearHistoryFileContents(env.historyFile)
+      await lib.initNetwork()
+      db = await lib.startDb()
+      auth = await lib.startAuth()
+      api = await lib.startApi()
+      const { user, collection } = await lib.initWatcherTestCollection()
+      env.collectionId = collection.collectionId
+      watcher = await lib.runWatcherPromise({ entry: "index.js", env, resolveOnMessage: `received shutdown event with code 0, exiting` })
+    })
+
+    after(async () => {
+      lib.stopProcesses([api, auth, db])
+    })
+
+    it("should use only requestScope as the token POST form.scope", async () => {
+      const tokenResponse = watcher.logRecords.find(r =>
+        r.message === 'http response' &&
+        r.request?.form?.grant_type === 'client_credentials'
+      )
+      expect(tokenResponse).to.exist
+      expect(tokenResponse.request.form.scope).to.equal(env.requestScope)
+    })
+
+    it("should not include default stig-manager scopes or extra scopes in the token request", async () => {
+      const tokenResponse = watcher.logRecords.find(r =>
+        r.message === 'http response' &&
+        r.request?.form?.grant_type === 'client_credentials'
+      )
+      expect(tokenResponse).to.exist
+      const scope = tokenResponse.request.form.scope
+      expect(scope).to.not.include('stig-manager:stig:read')
+      expect(scope).to.not.include('stig-manager:collection')
+      expect(scope).to.not.include('stig-manager:user:read')
+      expect(scope).to.not.include('stig-manager:extra-scope')
+    })
+
+  })
 })
 

--- a/test/e2e/lib.js
+++ b/test/e2e/lib.js
@@ -85,7 +85,9 @@ export async function runWatcherPromise ({
       `${env.cargoSize}`,
   ...(typeof (env.retryInterval ?? env.retryDelay) !== 'undefined' ? ['--retry-interval', `${env.retryInterval ?? env.retryDelay}`] : []),
   ...(typeof env.retryCount !== 'undefined' ? ['--retry-count', `${env.retryCount}`] : []),
-      ...(env.addExisting ? ['--add-existing'] : [])
+      ...(env.addExisting ? ['--add-existing'] : []),
+      ...(env.requestScope ? ['--request-scope', env.requestScope] : []),
+      ...(env.extraScopes ? ['--extra-scopes', env.extraScopes] : [])
     ]
 
     const watcherEnv = {
@@ -185,7 +187,9 @@ export async function runWatcher ({
       `${env.cargoSize}`,
   ...(typeof (env.retryInterval ?? env.retryDelay) !== 'undefined' ? ['--retry-interval', `${env.retryInterval ?? env.retryDelay}`] : []),
   ...(typeof env.retryCount !== 'undefined' ? ['--retry-count', `${env.retryCount}`] : []),
-      ...(env.addExisting ? ['--add-existing'] : [])
+      ...(env.addExisting ? ['--add-existing'] : []),
+      ...(env.requestScope ? ['--request-scope', env.requestScope] : []),
+      ...(env.extraScopes ? ['--extra-scopes', env.extraScopes] : [])
     ]
 
     const options = []


### PR DESCRIPTION
Resolves #212

This pull request adds a new option to allow overriding the default OAuth2 scope behavior and updates how scopes are constructed for authentication. The main changes are:

Authentication Scope Configuration:

- Added a new command-line option --request-scope (and corresponding environment variable WATCHER_REQUEST_SCOPE) in lib/args.js, allowing users to specify a single scope for the token request, which takes precedence over the default and extra scopes.
- Updated scope construction logic in lib/auth.js so that if requestScope is provided, only that scope is used; otherwise, the default and extra scopes are combined as before. Extra scopes are ignored if requestScope is set.