### PR TITLE
Pkg replacement

### DIFF
--- a/.github/workflows/backpressure.yml
+++ b/.github/workflows/backpressure.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: "20.x"
+        node-version: "24.x"
     - name: Install app dependencies
       run: npm ci
     - name: Create .env file

--- a/.github/workflows/build-binary-artifacts.yml
+++ b/.github/workflows/build-binary-artifacts.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 
@@ -80,8 +80,8 @@ jobs:
           done
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
-        if: always() 
+        uses: actions/upload-artifact@v7
+        if: always()
         with:
           name: binary-artifacts
           path: |

--- a/.github/workflows/build-binary-artifacts.yml
+++ b/.github/workflows/build-binary-artifacts.yml
@@ -10,6 +10,7 @@ on:
       - "lib/**"
       - "index.js"
       - "build.sh"
+      - "sea-config.json"
       - "nuwcdivnpt-bot.gpg.asc"
       - ".github/workflows/build-binary-artifacts.yml"
 jobs:
@@ -22,6 +23,11 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
 
       - name: run build script
         id: run_build_script

--- a/.github/workflows/build-binary-artifacts.yml
+++ b/.github/workflows/build-binary-artifacts.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
         with:
-          ref: main
           fetch-depth: 0
 
       - name: Set up Node.js

--- a/.github/workflows/build-binary-artifacts.yml
+++ b/.github/workflows/build-binary-artifacts.yml
@@ -33,42 +33,52 @@ jobs:
         id: run_build_script
         run: ./build.sh
 
-      - name: Import GPG Key
-        id: import_gpg
-        run: | 
-          if ! echo "${{ secrets.WATCHER_PRIVATE_KEY }}" | gpg --import; then
-            echo "::warning ::Private key GPG Import failed"
-            exit 1
-          fi
-      
       - name: Get version from package.json
         id: package_version
         run: echo "PACKAGE_VERSION=$(jq -r '.version' package.json)" >> $GITHUB_ENV
 
-      - name: Sign Artifacts
-        id: sign_artifacts
+      - name: Smoke test binaries
+        id: smoke_test
         run: |
-         if ! gpg --default-key nuwcdivnpt-bot@users.noreply.github.com --armor --detach-sig ./dist/stigman-watcher-linux-${{ env.PACKAGE_VERSION }}.tar.gz; then
-            echo "::warning ::Linux Signing failed"
+          ver="${{ env.PACKAGE_VERSION }}"
+          # glibc binary on host (ubuntu-latest is glibc)
+          ./bin/stigman-watcher-linux-glibc --version | grep -F "$ver"
+          ./bin/stigman-watcher-linux-glibc --help > /dev/null
+          # musl binary needs an Alpine container to execute
+          docker run --rm -v "$PWD/bin:/bin-mount" node:24-alpine sh -c "
+            /bin-mount/stigman-watcher-linux-musl --version | grep -F '$ver' &&
+            /bin-mount/stigman-watcher-linux-musl --help > /dev/null
+          "
+          # Windows binary can't be smoke-tested on ubuntu-latest without wine; skipped
+
+      - name: Import GPG Key
+        id: import_gpg
+        run: |
+          if ! echo "${{ secrets.WATCHER_PRIVATE_KEY }}" | gpg --import; then
+            echo "::warning ::Private key GPG Import failed"
             exit 1
           fi
-         if ! gpg --default-key nuwcdivnpt-bot@users.noreply.github.com --armor --detach-sig ./dist/stigman-watcher-win-${{ env.PACKAGE_VERSION }}.zip; then
-            echo "::warning ::Windows Signing failed"
-            exit 1
-         fi
-      
-      - name: Verify Signatures
-        id: verify_signatures
+
+      - name: Sign and Verify Artifacts
+        id: sign_artifacts
         working-directory: ./dist
         run: |
-          if ! gpg --verify stigman-watcher-linux-${{ env.PACKAGE_VERSION }}.tar.gz.asc stigman-watcher-linux-${{ env.PACKAGE_VERSION }}.tar.gz; then
-            echo "::warning ::Signature verification for Linux failed"
-            exit 1
-          fi
-          if ! gpg --verify stigman-watcher-win-${{ env.PACKAGE_VERSION }}.zip.asc stigman-watcher-win-${{ env.PACKAGE_VERSION }}.zip; then
-            echo "::warning ::Signature verification for Windows failed"
-            exit 1
-          fi
+          ver="${{ env.PACKAGE_VERSION }}"
+          artifacts=(
+            "stigman-watcher-linux-musl-${ver}.tar.gz"
+            "stigman-watcher-linux-glibc-${ver}.tar.gz"
+            "stigman-watcher-win-${ver}.zip"
+          )
+          for artifact in "${artifacts[@]}"; do
+            if ! gpg --default-key nuwcdivnpt-bot@users.noreply.github.com --armor --detach-sig "$artifact"; then
+              echo "::warning ::Signing failed for $artifact"
+              exit 1
+            fi
+            if ! gpg --verify "${artifact}.asc" "$artifact"; then
+              echo "::warning ::Signature verification failed for $artifact"
+              exit 1
+            fi
+          done
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,9 +12,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Important to fetch all history for accurate blame information
       - name: Analyze Watcher with SonarCloud

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,11 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
-    - name: Setup Node.js 
-      uses: actions/setup-node@v4
+      uses: actions/checkout@v6
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
       with:
-        node-version: "20.x"
+        node-version: "24.x"
     - name: Install app dependencies
       run: npm ci
     - name: Create .env file
@@ -38,7 +38,7 @@ jobs:
     - name: Run tests
       run: npm test
     - name: Upload coverage to github
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() }}
       with:
         name: coverage

--- a/README.md
+++ b/README.md
@@ -19,13 +19,26 @@ The client is suitable for use as a service or daemon, as a scheduled task, in a
 You can install Watcher using one of these methods:
 
 ### Copy a Release binary to a destination of your choice and execute
+
+Two Linux variants are published. Choose by your environment:
+
+- `stigman-watcher-linux-glibc` — for Ubuntu, Debian, RHEL, CentOS, Fedora, etc. (glibc-based distros). This is the right choice for most users.
+- `stigman-watcher-linux-musl` — for Alpine, distroless, and scratch-based container images (musl libc).
+
 ```
-$ ./stigman-watcher-linuxstatic [options]
+$ ./stigman-watcher-linux-glibc [options]
+```
+or
+```
+$ ./stigman-watcher-linux-musl [options]
 ```
 or
 ```
 C:/> stigman-watcher-win.exe [options]
-``` 
+```
+
+If the Linux binary is non-executable after extraction (some archive tools strip the exec bit), run `chmod +x stigman-watcher-linux-*` first.
+
 ### Install globally via NPM and run the module 
 ```
 $ npm install --global @nuwcdivnpt/stigman-watcher

--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,7 @@
 # - jq
 # - zip
 # - tar
+# - xz-utils (for extracting the official linux-x64 glibc node tarball)
 # - curl
 
 check_exit_status() {
@@ -52,43 +53,65 @@ printf "\n[BUILD_TASK] Generating SEA blob\n"
 node --experimental-sea-config sea-config.json
 check_exit_status "SEA blob generation" 3
 
-# Linux binary (musl-linked via Alpine Docker for broad compatibility)
-printf "\n[BUILD_TASK] Building Linux binary (musl-linked via Alpine)\n"
+# Linux musl binary (Alpine Docker — for Alpine/distroless/scratch containers)
+printf "\n[BUILD_TASK] Building Linux musl binary (via Alpine)\n"
 NODE_FULL_VERSION=$(docker run --rm -v "$PWD":/app -w /app node:24-alpine sh -c "
-  cp \$(command -v node) bin/stigman-watcher-linuxstatic && \
-  npx postject bin/stigman-watcher-linuxstatic NODE_SEA_BLOB sea-prep.blob \
+  cp \$(command -v node) bin/stigman-watcher-linux-musl && \
+  npx postject bin/stigman-watcher-linux-musl NODE_SEA_BLOB sea-prep.blob \
     --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 && \
   node -e 'console.log(process.version)'
 ")
-check_exit_status "Building Linux Binary" 4
+check_exit_status "Building Linux musl Binary" 4
 
-printf "[BUILD_TASK] Alpine Node version: $NODE_FULL_VERSION\n"
+# Same Node version is reused for the glibc and Windows targets so the SEA blob
+# stays portable across all three binaries (useCodeCache/useSnapshot are off).
+[ -n "$NODE_FULL_VERSION" ] || { echo "[BUILD_TASK] NODE_FULL_VERSION empty — Alpine step output capture failed"; exit 4; }
+printf "[BUILD_TASK] Node version (shared across targets): $NODE_FULL_VERSION\n"
+
+# Linux glibc binary (official linux-x64 tarball — for Ubuntu/Debian/RHEL/etc.)
+printf "\n[BUILD_TASK] Downloading Linux glibc Node.js $NODE_FULL_VERSION binary\n"
+curl -fSL -o node-linux-glibc.tar.xz \
+  "https://nodejs.org/dist/${NODE_FULL_VERSION}/node-${NODE_FULL_VERSION}-linux-x64.tar.xz"
+check_exit_status "Downloading Linux glibc Node" 5
+
+printf "\n[BUILD_TASK] Building Linux glibc binary\n"
+tar -xJf node-linux-glibc.tar.xz \
+  --strip-components=2 -C "$bin_dir" \
+  "node-${NODE_FULL_VERSION}-linux-x64/bin/node"
+mv "$bin_dir/node" "$bin_dir/stigman-watcher-linux-glibc"
+npx postject "$bin_dir/stigman-watcher-linux-glibc" NODE_SEA_BLOB sea-prep.blob \
+  --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
+check_exit_status "Building Linux glibc Binary" 6
 
 # Windows binary (download matching Windows node.exe, inject on host)
 printf "\n[BUILD_TASK] Downloading Windows Node.js $NODE_FULL_VERSION binary\n"
 curl -fSL -o node-win.exe \
   "https://nodejs.org/dist/${NODE_FULL_VERSION}/win-x64/node.exe"
-check_exit_status "Downloading Windows Node" 5
+check_exit_status "Downloading Windows Node" 7
 
 printf "\n[BUILD_TASK] Building Windows binary\n"
 cp node-win.exe $bin_dir/stigman-watcher-win.exe
 npx postject $bin_dir/stigman-watcher-win.exe NODE_SEA_BLOB sea-prep.blob \
   --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
-check_exit_status "Building Windows Binary" 6
+check_exit_status "Building Windows Binary" 8
 
-# Windows archive
+# Archives
 windows_archive=$dist_dir/stigman-watcher-win-$version.zip
 printf "\n[BUILD_TASK] Creating $windows_archive\n"
 zip --junk-paths $windows_archive ./dotenv-example $bin_dir/stigman-watcher-win.exe
-check_exit_status "Zipping Windows Archive" 7
+check_exit_status "Zipping Windows Archive" 9
 
-# Linux archive
-linux_archive=$dist_dir/stigman-watcher-linux-$version.tar.gz
-printf "\n[BUILD_TASK] Creating $linux_archive\n"
-tar -czvf $linux_archive --xform='s|^|stigman-watcher/|S' -C . dotenv-example -C $bin_dir stigman-watcher-linuxstatic
-check_exit_status "Tarring linux Archive" 8
+linux_musl_archive=$dist_dir/stigman-watcher-linux-musl-$version.tar.gz
+printf "\n[BUILD_TASK] Creating $linux_musl_archive\n"
+tar -czvf $linux_musl_archive --xform='s|^|stigman-watcher/|S' -C . dotenv-example -C $bin_dir stigman-watcher-linux-musl
+check_exit_status "Tarring Linux musl Archive" 10
+
+linux_glibc_archive=$dist_dir/stigman-watcher-linux-glibc-$version.tar.gz
+printf "\n[BUILD_TASK] Creating $linux_glibc_archive\n"
+tar -czvf $linux_glibc_archive --xform='s|^|stigman-watcher/|S' -C . dotenv-example -C $bin_dir stigman-watcher-linux-glibc
+check_exit_status "Tarring Linux glibc Archive" 11
 
 # Cleanup
-rm -f sea-prep.blob bundle.cjs node-win.exe
+rm -f sea-prep.blob bundle.cjs node-win.exe node-linux-glibc.tar.xz
 
 printf "\n[BUILD_TASK] Done\n"

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-# This file is used to build binaries on a Linux device. It is not tested elsewhere, yet.
+# This file is used to build binaries on a Linux device.
 # Requires:
-# - Node.js and module "pkg" (npm install -g pkg)
+# - Node.js 20+
+# - Docker (for musl-linked Linux binary)
 # - jq
 # - zip
 # - tar
+# - curl
 
 check_exit_status() {
   if [[ $? -eq 0 ]]; then
@@ -33,34 +35,60 @@ rm -rf $dist_dir/*
 printf "[BUILD_TASK] Fetching node_modules\n"
 rm -rf ./node_modules
 npm ci
-npm install -g pkg
 
-# Bundle
-printf "[BUILD_TASK] Bundling\n"
-npx esbuild index.js --bundle --platform=node --outfile=bundle.cjs
-check_exit_status "Bundling" 1
-
-# version=$(git describe --tags | sed 's/\(.*\)-.*/\1/')
-#get version from package.json
+# Get version from package.json
 version=$(jq -r .version package.json)
-check_exit_status "Getting Version" 5
+check_exit_status "Getting Version" 1
 printf "\n[BUILD_TASK] Using version string: $version\n"
 
-# Make binaries
-printf "\n[BUILD_TASK] Building binaries in $bin_dir\n"
-pkg -C gzip --public --public-packages=* --no-bytecode pkg.config.json
-check_exit_status "Building Binaries" 2
+# Bundle with esbuild, inlining the version
+printf "[BUILD_TASK] Bundling\n"
+npx esbuild index.js --bundle --platform=node --outfile=bundle.cjs \
+  --define:STIGMAN_WATCHER_VERSION=\"$version\"
+check_exit_status "Bundling" 2
+
+# Generate SEA blob
+printf "\n[BUILD_TASK] Generating SEA blob\n"
+node --experimental-sea-config sea-config.json
+check_exit_status "SEA blob generation" 3
+
+# Linux binary (musl-linked via Alpine Docker for broad compatibility)
+printf "\n[BUILD_TASK] Building Linux binary (musl-linked via Alpine)\n"
+NODE_FULL_VERSION=$(docker run --rm -v "$PWD":/app -w /app node:24-alpine sh -c "
+  cp \$(command -v node) bin/stigman-watcher-linuxstatic && \
+  npx postject bin/stigman-watcher-linuxstatic NODE_SEA_BLOB sea-prep.blob \
+    --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 && \
+  node -e 'console.log(process.version)'
+")
+check_exit_status "Building Linux Binary" 4
+
+printf "[BUILD_TASK] Alpine Node version: $NODE_FULL_VERSION\n"
+
+# Windows binary (download matching Windows node.exe, inject on host)
+printf "\n[BUILD_TASK] Downloading Windows Node.js $NODE_FULL_VERSION binary\n"
+curl -fSL -o node-win.exe \
+  "https://nodejs.org/dist/${NODE_FULL_VERSION}/win-x64/node.exe"
+check_exit_status "Downloading Windows Node" 5
+
+printf "\n[BUILD_TASK] Building Windows binary\n"
+cp node-win.exe $bin_dir/stigman-watcher-win.exe
+npx postject $bin_dir/stigman-watcher-win.exe NODE_SEA_BLOB sea-prep.blob \
+  --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
+check_exit_status "Building Windows Binary" 6
 
 # Windows archive
 windows_archive=$dist_dir/stigman-watcher-win-$version.zip
 printf "\n[BUILD_TASK] Creating $windows_archive\n"
 zip --junk-paths $windows_archive ./dotenv-example $bin_dir/stigman-watcher-win.exe
-check_exit_status "Zipping Windows Archive" 3
+check_exit_status "Zipping Windows Archive" 7
 
 # Linux archive
 linux_archive=$dist_dir/stigman-watcher-linux-$version.tar.gz
 printf "\n[BUILD_TASK] Creating $linux_archive\n"
 tar -czvf $linux_archive --xform='s|^|stigman-watcher/|S' -C . dotenv-example -C $bin_dir stigman-watcher-linuxstatic
-check_exit_status "Tarring linux Archive" 4
+check_exit_status "Tarring linux Archive" 8
+
+# Cleanup
+rm -f sea-prep.blob bundle.cjs node-win.exe
 
 printf "\n[BUILD_TASK] Done\n"

--- a/build.sh
+++ b/build.sh
@@ -54,18 +54,26 @@ node --experimental-sea-config sea-config.json
 check_exit_status "SEA blob generation" 3
 
 # Linux musl binary (Alpine Docker — for Alpine/distroless/scratch containers)
+# Inside the container, redirect postject/cp output to stderr so the captured
+# stdout contains only the Node version printed at the end. Both streams are
+# still visible in CI logs.
 printf "\n[BUILD_TASK] Building Linux musl binary (via Alpine)\n"
 NODE_FULL_VERSION=$(docker run --rm -v "$PWD":/app -w /app node:24-alpine sh -c "
-  cp \$(command -v node) bin/stigman-watcher-linux-musl && \
+  cp \$(command -v node) bin/stigman-watcher-linux-musl >&2 && \
   npx postject bin/stigman-watcher-linux-musl NODE_SEA_BLOB sea-prep.blob \
-    --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 && \
+    --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 >&2 && \
   node -e 'console.log(process.version)'
 ")
 check_exit_status "Building Linux musl Binary" 4
 
 # Same Node version is reused for the glibc and Windows targets so the SEA blob
 # stays portable across all three binaries (useCodeCache/useSnapshot are off).
-[ -n "$NODE_FULL_VERSION" ] || { echo "[BUILD_TASK] NODE_FULL_VERSION empty — Alpine step output capture failed"; exit 4; }
+# Validate format (vMAJOR.MINOR.PATCH) so a polluted capture fails fast rather
+# than corrupting downstream URLs.
+if ! [[ "$NODE_FULL_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "[BUILD_TASK] NODE_FULL_VERSION not a clean version string: '$NODE_FULL_VERSION'"
+  exit 4
+fi
 printf "[BUILD_TASK] Node version (shared across targets): $NODE_FULL_VERSION\n"
 
 # Linux glibc binary (official linux-x64 tarball — for Ubuntu/Debian/RHEL/etc.)

--- a/lib/args.js
+++ b/lib/args.js
@@ -15,6 +15,9 @@ const component = 'args'
 
 function getVersion() {
   try {
+    // STIGMAN_WATCHER_VERSION is inlined at bundle time via esbuild --define.
+    // The typeof guard preserves the package.json fallback for unbundled ESM
+    // dev runs (`node index.js`), where the global doesn't exist.
     if (typeof STIGMAN_WATCHER_VERSION !== 'undefined') {
       return STIGMAN_WATCHER_VERSION
     }

--- a/lib/args.js
+++ b/lib/args.js
@@ -5,7 +5,7 @@ import { Command, Option, InvalidOptionArgumentError } from 'commander'
 import { readFileSync } from 'node:fs'
 import * as logger from './logger.js'
 import { config } from 'dotenv' 
-import { dirname, resolve, sep, posix } from 'node:path'
+import { resolve, sep, posix } from 'node:path'
 import promptSync from 'prompt-sync'
 import { createPrivateKey } from 'crypto'
 import * as CONSTANTS from './consts.js'
@@ -15,9 +15,12 @@ const component = 'args'
 
 function getVersion() {
   try {
-    const packageJsonText = readFileSync(`${dirname(process?.pkg?.defaultEntrypoint ?? '.')}/package.json`, 'utf8')
+    if (typeof STIGMAN_WATCHER_VERSION !== 'undefined') {
+      return STIGMAN_WATCHER_VERSION
+    }
+    const packageJsonText = readFileSync(new URL('../package.json', import.meta.url), 'utf8')
     return JSON.parse(packageJsonText).version
-  } 
+  }
   catch (error) {
     console.error('Error reading package.json:', error.message)
     return '0.0.0'

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -1,6 +1,7 @@
 import { options } from './args.js'
 import { logger, getSymbol } from './logger.js'
 import Queue from 'better-queue'
+import MemoryStore from 'better-queue-memory'
 import * as api from './api.js'
 import { serializeError } from 'serialize-error'
 import { TaskObject } from '@nuwcdivnpt/stig-manager-client-modules'
@@ -148,6 +149,7 @@ const cargoQueue = new Queue(resultsHandler, {
   id: 'file',
   batchSize: options.cargoSize,
   batchDelay: options.oneShot ? 0 : options.cargoDelay,
+  store: new MemoryStore()
 })
 cargoQueue
 .on('batch_failed', (err) => {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,5 +1,6 @@
 import { cache } from './api.js'
 import Queue from 'better-queue'
+import MemoryStore from 'better-queue-memory'
 import { logger } from './logger.js'
 import { cargoQueue } from './cargo.js'
 import { promises as fs } from 'fs'
@@ -149,7 +150,8 @@ async function parseFileAndEnqueue (file, cb) {
 }
 
 export const parseQueue = new Queue (parseFileAndEnqueue, {
-  concurrent: 8
+  concurrent: 8,
+  store: new MemoryStore()
 })
 
 Alarm.on('alarmRaised', onAlarmRaised)

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "chai": "^6.0.1",
         "esbuild": "^0.25.9",
         "mocha": "11.7.5",
+        "postject": "^1.0.0-alpha.6",
         "testcontainers": "^11.5.1"
       },
       "engines": {
@@ -3175,6 +3176,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/postject/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/process": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@nuwcdivnpt/stig-manager-client-modules": "^1.6.7",
         "atob": "^2.1.2",
         "better-queue": "^3.8.10",
+        "better-queue-memory": "^1.0.4",
         "chokidar": "^3.5.1",
         "commander": "^7.2.0",
         "dotenv": "^8.2.0",
@@ -35,7 +36,7 @@
         "testcontainers": "^11.5.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/@balena/dockerignore": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@nuwcdivnpt/stig-manager-client-modules": "^1.6.7",
     "atob": "^2.1.2",
     "better-queue": "^3.8.10",
+    "better-queue-memory": "^1.0.4",
     "chokidar": "^3.5.1",
     "commander": "^7.2.0",
     "dotenv": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "c8 --reporter=html --reporter=text mocha"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=20"
   },
   "dependencies": {
     "@nuwcdivnpt/stig-manager-client-modules": "^1.6.3",
@@ -36,12 +36,13 @@
   "overrides": {
     "serialize-javascript": "^7.0.4",
     "diff": "^8.0.3"
-  },  
+  },
   "devDependencies": {
     "c8": "^10.1.3",
     "chai": "^6.0.1",
     "esbuild": "^0.25.9",
     "mocha": "11.7.5",
+    "postject": "^1.0.0-alpha.6",
     "testcontainers": "^11.5.1"
   }
 }

--- a/pkg.config.json
+++ b/pkg.config.json
@@ -1,9 +1,0 @@
-{
-    "name": "stigman-watcher",
-    "bin": "./bundle.cjs",
-    "pkg": {
-        "targets": [ "node18-win", "node18-linuxstatic" ],
-        "assets": ["./node_modules/better-queue-memory/**", "./package.json"],
-        "outputPath": "./bin"
-    }
-}

--- a/sea-config.json
+++ b/sea-config.json
@@ -1,0 +1,7 @@
+{
+  "main": "bundle.cjs",
+  "output": "sea-prep.blob",
+  "disableExperimentalSEAWarning": true,
+  "useCodeCache": false,
+  "useSnapshot": false
+}


### PR DESCRIPTION
# Migrate binary builds from `pkg` to Node.js SEA

## Summary

Replaces the deprecated `pkg` toolchain with Node.js Single Executable Applications (SEA) for binary distribution. This is the **fix path for the v1.6.7 runtime crash** and unblocks future Node-version upgrades that pkg can never reach.

### Why this is the v1.6.7 fix

v1.6.7 added `"uuid": "^14.0.0"` to `package.json` overrides to silence GHSA-w5hq-g745-h8pq for downstream dependency scanners. uuid v14 dropped `node:crypto` and uses the Web Crypto global (`globalThis.crypto`), which is unflagged-global only on Node 19+. The released pkg binaries embed Node 18.5.0, so they crash on first queue use:

```
ReferenceError: crypto is not defined
    at Object.v4 (/snapshot/.../bundle.cjs)
    at Queue3._queueTask
```

Rolling back the uuid override would re-introduce audit noise. Node 18 is also EOL (April 2025). The right answer is to ship binaries embedding a maintained Node version — Node 24 in this PR.

## What's in this PR

### Build pipeline: pkg → SEA

- `pkg.config.json` removed; `pkg` removed from devDependencies
- `esbuild` + `postject` added; entry bundled to `bundle.cjs`, SEA blob injected into a copy of the official `node` binary
- New `sea-config.json` — keeps `useCodeCache: false` and `useSnapshot: false` so the same blob is portable across all three target binaries
- Node 24 embedded in every binary

### Three binary targets (one new)

| Target | Source of `node` | Filename |
|---|---|---|
| Linux glibc *(new)* | nodejs.org `node-${ver}-linux-x64.tar.xz` | `stigman-watcher-linux-glibc` |
| Linux musl | `node:24-alpine` Docker image | `stigman-watcher-linux-musl` *(was `linuxstatic`)* |
| Windows | nodejs.org `win-x64/node.exe` | `stigman-watcher-win.exe` |

The previous `pkg` binary worked on both glibc and musl Linux distros. SEA injects into the *official* node binary, which is dynamically linked — so a single Linux binary no longer covers both. Two Linux variants is the standard post-pkg approach.

**Breaking change for consumers:** `stigman-watcher-linuxstatic` is renamed to `stigman-watcher-linux-musl`. README updated with selection guidance (default to glibc; choose musl for Alpine/distroless containers).

### Code changes for SEA-compatibility

- **`lib/parse.js`, `lib/cargo.js`** — `better-queue` does `require('better-queue-' + store)` internally. esbuild can't statically resolve dynamic requires, so `better-queue-memory` wouldn't be in the SEA bundle. Fixed by importing `MemoryStore` directly and passing an instance via the `store` option, which bypasses the dynamic-require code path entirely.
- **`package.json`** — promoted `better-queue-memory` from transitive to direct dependency.
- **`lib/args.js`** — `getVersion()` now reads `STIGMAN_WATCHER_VERSION` (inlined at bundle time via esbuild `--define`) with an `import.meta.url` package.json fallback for unbundled ESM dev runs (`node index.js`). Comment added explaining the dual-path pattern.

### CI workflow improvements (`.github/workflows/build-binary-artifacts.yml`)

- **Pre-signing smoke test** — runs `--version` and `--help` against both Linux binaries (glibc on host, musl in an Alpine container) so a broken bundle fails CI before it can get GPG-signed and uploaded. Windows binary is skipped (no wine on the runner).
- **Sign/verify generalized** to a single loop over an artifacts array instead of duplicated stanzas per filename.
- **Checkout ref** dropped (was hardcoded to `main`) — defaults to `github.ref`, so workflow_dispatch builds whatever branch you trigger from, and release events build the released tag.

### GitHub Actions version bumps (all workflows)

Silences the September 2026 Node 20 deprecation warning by bumping all five workflows to the latest majors:

- `actions/checkout@v4` → `@v6`
- `actions/setup-node@v4` → `@v6`
- `actions/upload-artifact@v4` → `@v7`

Verified that no v5/v6/v7 behavior change affects current usage.

### Test workflows on Node 24

`testing.yml` and `backpressure.yml` previously pinned `node-version: 20.x`. Bumped to `24.x` to match what the binaries embed — testing what we ship.

> Note: `package.json` `engines.node` left at `>=20` (npm consumers can still install on Node 20). If you'd rather hold npm consumers to the same Node 24 floor as binary users, bump that to `>=24` separately.

## Test plan

- [ ] Workflow `Build and Sign Binary Artifacts` runs end-to-end on workflow_dispatch from this branch
- [ ] Smoke-test step passes for both Linux binaries (`--version` matches `package.json`, `--help` renders without crash)
- [ ] All three archives present in `dist/`: `stigman-watcher-linux-glibc-${ver}.tar.gz`, `stigman-watcher-linux-musl-${ver}.tar.gz`, `stigman-watcher-win-${ver}.zip`
- [ ] GPG signing + verification succeeds for all three artifacts
- [ ] Workflow `Run Tests and Upload Coverage Artifact` passes on Node 24
- [ ] Manually run a built `stigman-watcher-linux-glibc` against a real CKL file end-to-end — verify the original v1.6.7 crash (`ReferenceError: crypto is not defined`) does not recur, and the previously-flagged dynamic-require path (`Cannot find module 'better-queue-memory'`) does not surface
- [ ] Verify `stigman-watcher-linux-musl` runs in an Alpine container

## Release notes (suggested)

> **Breaking:** the Linux binary `stigman-watcher-linuxstatic` is replaced by two variants: `stigman-watcher-linux-glibc` (default — Ubuntu/Debian/RHEL/etc.) and `stigman-watcher-linux-musl` (Alpine/distroless containers). Update any automation pinned to the old filename. Windows binary is unchanged.
>
> Internally, binaries now use Node.js Single Executable Applications instead of the deprecated `pkg`. The embedded Node version is 24.
